### PR TITLE
Development v1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'solidus', github: 'solidusio/solidus', branch: 'v1.0'
+gem 'solidus', github: 'solidusio/solidus', branch: 'v1.1'
 
 if ENV['DB'] == 'mysql'
   gem 'mysql2', '~> 0.3.20'

--- a/app/assets/javascripts/spree/frontend/cart_decorator.js.coffee
+++ b/app/assets/javascripts/spree/frontend/cart_decorator.js.coffee
@@ -1,5 +1,0 @@
-Spree.fetch_cart = (cartLinkUrl) ->
-  Spree.ajax
-    url: cartLinkUrl || Spree.pathFor("cart_link"),
-    success: (data) ->
-      $('#link-to-cart').html data

--- a/app/overrides/spree/shared/_main_nav_bar/cart_link.html.erb.deface
+++ b/app/overrides/spree/shared/_main_nav_bar/cart_link.html.erb.deface
@@ -1,9 +1,0 @@
-<!-- replace_contents '#main-nav-bar' -->
-<li id="home-link" data-hook><%= link_to Spree.t(:home), spree.root_path %></li>
-<li id="link-to-cart" data-hook>
-  <noscript>
-    <%= link_to Spree.t(:cart), '/cart' %>
-  </noscript>
-  &nbsp;
-</li>
-<script>Spree.fetch_cart('<%= j cart_link_url %>')</script>

--- a/solidus_i18n.gemspec
+++ b/solidus_i18n.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rails-i18n', '~> 4.0.1'
   s.add_runtime_dependency 'kaminari-i18n', '~> 0.3.2'
   s.add_runtime_dependency 'routing-filter', '~> 0.5.0'
-  s.add_runtime_dependency 'solidus_core', '~> 1.0'
+  s.add_runtime_dependency 'solidus_core', '~> 1.1'
   s.add_runtime_dependency 'deface', '~> 1.0'
 
   s.add_development_dependency 'byebug'


### PR DESCRIPTION
**Branch v.1.1 / Master**

Same thing as #1 (who will be v.1.0)

Difference is a version bump and removal of cart_decorator.js and override (which was added before the fork between my branch so not in this fork) who added missing params for automated translations of cart_link