### PR TITLE
Convert bg translations from solidus 1.2 -> 1.3

### DIFF
--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -1,16 +1,18 @@
+---
 bg:
   activerecord:
     attributes:
       spree/address:
-        address1: "Адрес"
-        address2: "Адрес (продъл.)"
-        city: "Град"
-        country: "Държава"
-        firstname: "Име"
-        lastname: "Фамилия"
-        phone: "Телефон"
-        state: "Област"
-        zipcode: "Пощенски код"
+        address1: Адрес
+        address2: Адрес (продъл.)
+        city: Град
+        country: Държава
+        firstname: Име
+        lastname: Фамилия
+        phone: Телефон
+        state: Област
+        zipcode: Пощенски код
+        company: Компания
       spree/calculator/tiered_flat_rate:
         preferred_base_amount:
         preferred_tiers:
@@ -21,93 +23,125 @@ bg:
         iso: ISO
         iso3: ISO3
         iso_name: ISO Име
-        name: "Име"
+        name: Име
         numcode: ISO Код
+        states_required:
       spree/credit_card:
         base:
         cc_type: Type
-        month: "Месец"
+        month: Месец
         name:
-        number: "Номер"
-        verification_value: "Стойност за потвърждение"
-        year: "Година"
+        number: Номер
+        verification_value: Стойност за потвърждение
+        year: Година
+        card_code: Код на карта
+        expiration: Срок на годност
       spree/inventory_unit:
         state: County Държава
       spree/line_item:
-        price: "Цена"
-        quantity: "Количество"
+        price: Цена
+        quantity: Количество
+        description: Описание на предмет
+        name: Име
+        total:
       spree/option_type:
-        name: "Име"
-        presentation: "Презентация"
+        name: Име
+        presentation: Презентация
       spree/order:
-        checkout_complete: "Завършена поръчка"
-        completed_at: "Завършена на"
+        checkout_complete: Завършена поръчка
+        completed_at: Завършена на
         considered_risky:
-        coupon_code: "Код на ваучер"
-        created_at: "Дата на поръчка"
-        email: "Клиентски и-мейл"
+        coupon_code: Код на ваучер
+        created_at: Дата на поръчка
+        email: Клиентски и-мейл
         ip_address: IP Адрес
-        item_total: "Общо"
-        number: "Номер"
-        payment_state: "Състояние на плащане"
-        shipment_state: "Състояние на доставка"
-        special_instructions: "Специални инструкции"
-        state: "Държава"
-        total: "Общо"
+        item_total: Общо
+        number: Номер
+        payment_state: Състояние на плащане
+        shipment_state: Състояние на доставка
+        special_instructions: Специални инструкции
+        state: Държава
+        total: Общо
+        additional_tax_total:
+        approved_at:
+        approver_id:
+        canceled_at:
+        canceler_id:
+        included_tax_total:
+        shipment_total: Общо
       spree/order/bill_address:
-        address1: "Адрес за плащане -улица"
-        city: "Адрес за плащане - град"
-        firstname: "първо име"
-        lastname: "фамилия"
-        phone: "тел. номер"
-        state: "община"
-        zipcode: "пощенски код"
+        address1: Адрес за плащане -улица
+        city: Адрес за плащане - град
+        firstname: първо име
+        lastname: фамилия
+        phone: тел. номер
+        state: община
+        zipcode: пощенски код
       spree/order/ship_address:
-        address1: "Адрес за доставка - улица"
-        city: "Адрес за доставка - град"
-        firstname: "Адрес за доставка -първо име"
-        lastname: "Адрес за доставка - фамилия"
-        phone: "Адрес за доставка - тел. номер"
+        address1: Адрес за доставка - улица
+        city: Адрес за доставка - град
+        firstname: Адрес за доставка -първо име
+        lastname: Адрес за доставка - фамилия
+        phone: Адрес за доставка - тел. номер
         state: county Адрес за доставка - община
-        zipcode: "Адрес за доставка - пощ. код"
+        zipcode: Адрес за доставка - пощ. код
       spree/payment:
-        amount: "Сума"
+        amount: Сума
+        number:
+        response_code:
+        state: Статус на плащането
       spree/payment_method:
-        name: "Име"
+        name: Име
+        active: Активен
+        auto_capture:
+        description:
+        display_on:
+        type: Доставчик
       spree/product:
-        available_on: "В наличност от"
-        cost_currency: "Валута"
-        cost_price: "Цена"
-        description: "Описание"
-        master_price: "Крайна цена"
-        name: "Име"
-        on_hand: "В наличие"
-        shipping_category: "Доставна категория"
-        tax_category: "Данъчна категория"
+        available_on: В наличност от
+        cost_currency: Валута
+        cost_price: Цена
+        description: Описание
+        master_price: Крайна цена
+        name: Име
+        on_hand: В наличие
+        shipping_category: Доставна категория
+        tax_category: Данъчна категория
+        depth:
+        height: Височина
+        meta_description: Описание
+        meta_keywords: Ключови думи
+        meta_title:
+        price: Главна сума
+        promotionable:
+        slug:
+        weight: Тежест
+        width: Ширина
       spree/promotion:
-        advertise: "Рекламирай"
+        advertise: Рекламирай
         code: Code Код
-        description: "Описание"
-        event_name: "Име на акция"
-        expires_at: "Изтича на"
-        name: "Име"
-        path: "Път"
-        starts_at: "Започва на"
-        usage_limit: "Лимит"
+        description: Описание
+        event_name: Име на акция
+        expires_at: Изтича на
+        name: Име
+        path: Път
+        starts_at: Започва на
+        usage_limit: Лимит
       spree/promotion_category:
         name:
       spree/property:
-        name: "Име"
-        presentation: "Презентация"
+        name: Име
+        presentation: Презентация
       spree/prototype:
-        name: "Име"
+        name: Име
       spree/return_authorization:
-        amount: "Количество"
+        amount: Количество
+        pre_tax_total:
       spree/role:
-        name: "Име"
+        name: Име
       spree/state:
-        abbr: "Съкращение"
-        name: "Име"
+        abbr: Съкращение
+        name: Име
       spree/state_change:
         state_changes:
         state_from:
@@ -124,34 +158,155 @@ bg:
         seo_title:
         url:
       spree/tax_category:
-        description: "Описание"
-        name: "Име"
+        description: Описание
+        name: Име
+        is_default:
+        tax_code:
       spree/tax_rate:
-        amount: "Процент"
-        included_in_price: "Включен в цената"
+        amount: Процент
+        included_in_price: Включен в цената
         show_rate_in_label: label Покажи процента в цената
+        name: Име
       spree/taxon:
-        name: "Име"
+        name: Име
         permalink: Permalink
-        position: "Позиция"
+        position: Позиция
+        description:
+        icon: Икона
+        meta_description: Описание
+        meta_keywords: Ключови думи
+        meta_title:
       spree/taxonomy:
-        name: "Име"
+        name: Име
       spree/user:
         email: l И-мейл
-        password: "Парола"
-        password_confirmation: "Повтори парола"
+        password: Парола
+        password_confirmation: Повтори парола
       spree/variant:
-        cost_currency: "Валута"
+        cost_currency: Валута
         cost_price: Price Цена
-        depth: "Дълбочина"
-        height: "Височина"
-        price: "Цена"
+        depth: Дълбочина
+        height: Височина
+        price: Цена
         sku: SKU
-        weight: "Тежест"
-        width: "Ширина"
+        weight: Тежест
+        width: Ширина
       spree/zone:
-        description: "Описание"
-        name: "Име"
+        description: Описание
+        name: Име
+        default_tax:
+      spree/adjustment:
+        adjustable:
+        amount: Сума
+        label:
+        name: Име
+        state:
+        adjustment_reason_id: Причина
+      spree/adjustment_reason:
+        active: Активен
+        code: Код
+        name: Име
+        state:
+      spree/carton:
+        tracking:
+      spree/customer_return:
+        number:
+        pre_tax_total:
+        total: Общо
+        reimbursement_status:
+        name: Име
+      spree/image:
+        alt: Алтернативен текст
+        attachment: Име на файл
+      spree/legacy_user:
+        email:
+        password: Парола
+        password_confirmation: Потвърди парола
+      spree/option_value:
+        name: Име
+        presentation:
+      spree/product_property:
+        value: Стойност
+      spree/refund:
+        amount: Сума
+        description:
+        refund_reason_id: Причина
+      spree/refund_reason:
+        active: Активен
+        name: Име
+        code: Код
+      spree/reimbursement:
+        number: Номер
+        reimbursement_status:
+        total: Общо
+      spree/reimbursement/credit:
+        amount: Сума
+      spree/reimbursement_type:
+        name: Име
+        type: Тип
+      spree/return_item:
+        acceptance_status:
+        acceptance_status_errors:
+        charged:
+        exchange_variant:
+        inventory_unit_state:
+        override_reimbursement_type_id:
+        preferred_reimbursement_type_id:
+        reception_status:
+        return_reason: Причина
+        total: Общо
+      spree/return_reason:
+        name: Име
+        active: Активен
+        memo:
+        number:
+        state:
+      spree/shipping_category:
+        name: Име
+      spree/shipment:
+        tracking:
+      spree/shipping_method:
+        admin_name: Вътрешно име.
+        code: Код
+        display_on:
+        name: Име
+        tracking_url:
+      spree/shipping_rate:
+        tax_rate: Данъчен процент
+        amount: Сума
+      spree/store_credit:
+        amount: Сума
+        memo:
+      spree/store_credit_event:
+        action: Действие
+      spree/stock_item:
+        count_on_hand:
+      spree/stock_location:
+        admin_name: Вътрешно име.
+        active: Активен
+        address1:
+        address2:
+        backorderable_default:
+        city: Град
+        code: Код
+        country_id: Страна
+        default:
+        internal_name: Вътрешно име.
+        name: Име
+        phone: Телефон
+        propagate_all_variants:
+        state_id:
+        zipcode: пощ. кид
+      spree/stock_movement:
+        action: Действие
+        quantity: Количество
+      spree/stock_transfer:
+        created_at: Създаден на
+        description:
+        tracking_number:
+      spree/tracker:
+        analytics_id: Идентифиционен номер на аналитиката
+        active: Активен
     errors:
       models:
         spree/calculator/tiered_flat_rate:
@@ -174,7 +329,7 @@ bg:
         spree/credit_card:
           attributes:
             base:
-              card_expired: "Картата е изтекла"
+              card_expired: Картата е изтекла
               expiry_invalid:
         spree/line_item:
           attributes:
@@ -200,191 +355,247 @@ bg:
               cannot_destroy_default_store:
     models:
       spree/address:
-        one: "Адрес"
-        other: "Адреси"
+        one: Адрес
+        other: Адреси
       spree/country:
-        one: "Държава"
-        other: "Държави"
+        one: Държава
+        other: Държави
       spree/credit_card:
-        one: "Кредитна карта"
-        other: "Кредитни карти"
+        one: Кредитна карта
+        other: Кредитни карти
       spree/customer_return:
+        one:
+        other:
       spree/inventory_unit:
-        one: "Складна единица"
-        other: "Складни единици"
+        one: Складна единица
+        other: Складни единици
       spree/line_item:
       spree/option_type:
+        one:
+        other:
       spree/option_value:
+        one:
+        other:
       spree/order:
-        one: "Поръчка"
-        other: "Поръчки"
+        one: Поръчка
+        other: Поръчки
       spree/payment:
-        one: "Плащане"
-        other: "Плащания"
+        one: Плащане
+        other: Плащания
       spree/payment_method:
+        one: Начин на плащане
+        other: Методи на плащане
       spree/product:
-        one: "Продукт"
-        other: "Продукти"
+        one: Продукт
+        other: Продукти
       spree/promotion:
+        one:
+        other:
       spree/promotion_category:
+        other:
       spree/property:
-        one: "Харатеристика"
-        other: "Характеристики"
+        one: Харатеристика
+        other: Характеристики
       spree/prototype:
-        one: "Прототип"
-        other: "Прототипи"
+        one: Прототип
+        other: Прототипи
       spree/refund_reason:
+        other:
       spree/reimbursement:
+        one:
+        other:
       spree/reimbursement_type:
+        other:
       spree/return_authorization:
-        one: "Върни ауторизация"
-        other: "Върни ауторизации"
+        one: Върни ауторизация
+        other: Върни ауторизации
       spree/return_authorization_reason:
       spree/role:
-        one: "Роли"
-        other: "Роли"
+        one: Роли
+        other: Роли
       spree/shipment:
-        one: "Доставка"
-        other: "Доставки"
+        one: Доставка
+        other: Доставки
       spree/shipping_category:
-        one: "Доставна категория"
-        other: "Доставни категории"
+        one: Доставна категория
+        other: Доставни категории
       spree/shipping_method:
+        one:
+        other:
       spree/state:
-        one: "Държава"
-        other: "Държави"
+        one: Държава
+        other: Държави
       spree/state_change:
       spree/stock_location:
+        one:
+        other:
       spree/stock_movement:
+        other:
       spree/stock_transfer:
+        one:
+        other:
       spree/tax_category:
-        one: "Данъчна категория"
-        other: "Данъчна категория"
+        one: Данъчна категория
+        other: Данъчна категория
       spree/tax_rate:
-        one: "Данъчен процент"
-        other: "данъчни проценти"
+        one: Данъчен процент
+        other: данъчни проценти
       spree/taxon:
+        one:
+        other: Таксони
       spree/taxonomy:
+        one: Таксономия
+        other: Таксономии
       spree/tracker:
+        other:
       spree/user:
-        one: "Потребител"
-        other: "Потребители"
+        one: Потребител
+        other: Потребители
       spree/variant:
-        one: "Вариант"
-        other: "Варианти"
+        one: Вариант
+        other: Варианти
       spree/zone:
         one: Zone Зона
-        other: "Зони"
+        other: Зони
+      spree/adjustment:
+        one: Поправка
+        other: Поправки
+      spree/calculator:
+        one: Калкулатор
+      spree/legacy_user:
+        one: User
+        other: Потребители
+      spree/log_entry:
+        other:
+      spree/product_property:
+        other:
+      spree/refund:
+        one:
+        other:
+      spree/store_credit_category:
+        one: Категория
+        other: Категории
   devise:
     confirmations:
-      confirmed: "Вашият акаунт е потвърден. Вече сте вписан."
-      send_instructions: "До няколко минути ще получите съобщение с обяснение как да потвърдите своя акаунт."
+      confirmed: Вашият акаунт е потвърден. Вече сте вписан.
+      send_instructions: До няколко минути ще получите съобщение с обяснение как да потвърдите своя акаунт.
     failure:
-      inactive: "Вашият акаунт все още не е активен."
-      invalid: "Грешен имейл или парола"
+      inactive: Вашият акаунт все още не е активен.
+      invalid: Грешен имейл или парола
       invalid_token: Invalid authentication token.
-      locked: "Вашият акаунт е заключен."
-      timeout: "Вашата сесия е изтекла, моля влезте повторно."
-      unauthenticated: "Трябва да се впишете или регистрирате преди да продължите"
-      unconfirmed: "Трябва да потвърдите акаунта си преди да продължите."
+      locked: Вашият акаунт е заключен.
+      timeout: Вашата сесия е изтекла, моля влезте повторно.
+      unauthenticated: Трябва да се впишете или регистрирате преди да продължите
+      unconfirmed: Трябва да потвърдите акаунта си преди да продължите.
     mailer:
       confirmation_instructions:
-        subject: "Инструкции за потвърждаване"
+        subject: Инструкции за потвърждаване
       reset_password_instructions:
         subject: Reset password instructions Инструкции за смяна на паролата
       unlock_instructions:
-        subject: "Инструкции за отключване"
+        subject: Инструкции за отключване
     oauth_callbacks:
       failure: Could not authorise you from %{kind} because %{reason}.
       success: Successfully authorised from %{kind} account.
     unlocks:
-      send_instructions: "До няколко минути ще получите имейл с инструкции как да отключите своя акаунт."
-      unlocked: "Вашият акаунт бе отключен успешно. Вече сте вписани."
+      send_instructions: До няколко минути ще получите имейл с инструкции как да отключите своя акаунт.
+      unlocked: Вашият акаунт бе отключен успешно. Вече сте вписани.
     user_passwords:
       user:
-        cannot_be_blank: "Вашата парола не може бъде празна"
-        send_instructions: "До няколко минути ще получите имейл с инструкции как да промените паролата си."
-        updated: "Вашата парола бе променена успешко. Вече сте вписани."
+        cannot_be_blank: Вашата парола не може бъде празна
+        send_instructions: До няколко минути ще получите имейл с инструкции как да промените паролата си.
+        updated: Вашата парола бе променена успешко. Вече сте вписани.
     user_registrations:
-      destroyed: "Вашият акаунт бе отменен успешно. Надяваме се да ви видим скоро."
+      destroyed: Вашият акаунт бе отменен успешно. Надяваме се да ви видим скоро.
       inactive_signed_up: You have signed up successfully. However, we could not sign you in because your account is %{reason}.
-      signed_up: "Вие се регистрирахте успешно."
-      updated: "Успешно обновихте своя акаунт."
+      signed_up: Вие се регистрирахте успешно.
+      updated: Успешно обновихте своя акаунт.
     user_sessions:
-      signed_in: "Успешно влизане"
-      signed_out: "Успешно излизане"
+      signed_in: Успешно влизане
+      signed_out: Успешно излизане
   errors:
     messages:
-      already_confirmed: "Вече бе потвърден"
-      not_found: "не намерен"
-      not_locked: "не бе заключен"
+      already_confirmed: Вече бе потвърден
+      not_found: не намерен
+      not_locked: не бе заключен
       not_saved:
-        one: "Една грешка предоотврати запазването на %{resource}"
+        one: Една грешка предоотврати запазването на %{resource}
         other: "%{count} грешки предоотвратиха запазването на %{resource}"
   spree:
-    abbreviation: "Абривиатура"
+    abbreviation: Абривиатура
     accept:
     acceptance_errors:
     acceptance_status:
     accepted:
-    account: "Акаунт"
-    account_updated: "Акаунтът бе обновен!"
-    action: "Действие"
+    account: Акаунт
+    account_updated: Акаунтът бе обновен!
+    action: Действие
     actions:
-      cancel: "Отмени"
-      continue: "Продължи"
-      create: "Създай"
-      destroy: "Унищожи"
-      edit: "Редактирай"
-      list: "Списък"
+      cancel: Отмени
+      continue: Продължи
+      create: Създай
+      destroy: Унищожи
+      edit: Редактирай
+      list: Списък
       listing: Listing
-      new: "Нов"
+      new: Нов
       refund:
-      save: "Запази"
-      update: "Обновни"
-    activate: "Активирай"
-    active: "Активен"
-    add: "Добави"
-    add_action_of_type: "Добави действие от тип"
-    add_country: "Добави страна"
+      save: Запази
+      update: Обновни
+      add: Добави
+      delete: Изтрий
+      remove: Премахни
+      ship: прати
+      split:
+    activate: Активирай
+    active: Активен
+    add: Добави
+    add_action_of_type: Добави действие от тип
+    add_country: Добави страна
     add_coupon_code:
-    add_new_header: "Добави нов хедър"
-    add_new_style: "Добави нов стил"
-    add_one: "Добави едно"
-    add_option_value: "Добави опционална стойност"
-    add_product: "Добави продукт"
-    add_product_properties: "Добави характеристики на продукт"
-    add_rule_of_type: "Добави правило от тип"
-    add_state: "Добави състояние"
-    add_stock: "добави стока"
-    add_stock_management: "Добави управление на стока"
-    add_to_cart: "Добави в кошницата"
-    add_variant: "Добави вариант"
+    add_new_header: Добави нов хедър
+    add_new_style: Добави нов стил
+    add_one: Добави едно
+    add_option_value: Добави опционална стойност
+    add_product: Добави продукт
+    add_product_properties: Добави характеристики на продукт
+    add_rule_of_type: Добави правило от тип
+    add_state: Добави състояние
+    add_stock: добави стока
+    add_stock_management: Добави управление на стока
+    add_to_cart: Добави в кошницата
+    add_variant: Добави вариант
     additional_item: Additional Цена на артикул
-    address1: "Адрес"
-    address2: "Адрес (продължение)"
+    address1: Адрес
+    address2: Адрес (продължение)
     adjustable:
-    adjustment: "Поправка"
-    adjustment_amount: "Стойност"
-    adjustment_successfully_closed: "Поправката бе успешно затворена"
-    adjustment_successfully_opened: "Поправката бе успешно отворена"
-    adjustment_total: "Обща стойност на поправката"
-    adjustments: "Поправки"
+    adjustment: Поправка
+    adjustment_amount: Стойност
+    adjustment_successfully_closed: Поправката бе успешно затворена
+    adjustment_successfully_opened: Поправката бе успешно отворена
+    adjustment_total: Обща стойност на поправката
+    adjustments: Поправки
     admin:
       tab:
-        configuration: "Конфигурация"
+        configuration: Конфигурация
         option_types:
-        orders: "Поръчки"
-        overview: "Прегледай"
-        products: "Продукти"
-        promotions: "Промоции"
+        orders: Поръчки
+        overview: Прегледай
+        products: Продукти
+        promotions: Промоции
         promotion_categories:
         properties:
         prototypes:
-        reports: "Доклади"
+        reports: Доклади
         taxonomies:
         taxons:
-        users: "Потребители"
+        users: Потребители
+        checkout: Плащане
+        general: Генерален
+        payments: Плащания
+        settings: Настройки
+        shipping: Пратки
+        stock:
       user:
         account:
         addresses:
@@ -394,22 +605,22 @@ bg:
         order_num:
         orders:
         user_information:
-    administration: "Администрация"
+    administration: Администрация
     advertise:
-    agree_to_privacy_policy: "Съгласен съм с политиката за защита на лични данни"
-    agree_to_terms_of_service: "Съгласен съм с Общите условия"
-    all: "Всички"
-    all_adjustments_closed: "Всички промени завършени успешно!"
-    all_adjustments_opened: "Всички промени отворено успешно!"
-    all_departments: "Всички отдели"
+    agree_to_privacy_policy: Съгласен съм с политиката за защита на лични данни
+    agree_to_terms_of_service: Съгласен съм с Общите условия
+    all: Всички
+    all_adjustments_closed: Всички промени завършени успешно!
+    all_adjustments_opened: Всички промени отворено успешно!
+    all_departments: Всички отдели
     all_items_have_been_returned:
-    allow_ssl_in_development_and_test: "Позволи SSL да бъде ползвано при тестов режим"
+    allow_ssl_in_development_and_test: Позволи SSL да бъде ползвано при тестов режим
     allow_ssl_in_production:
     allow_ssl_in_staging:
     already_signed_up_for_analytics:
-    alt_text: "Алтернативен текст"
-    alternative_phone: "Алтернативен телефон"
-    amount: "Сума"
+    alt_text: Алтернативен текст
+    alternative_phone: Алтернативен телефон
+    amount: Сума
     analytics_desc_header_1:
     analytics_desc_header_2:
     analytics_desc_list_1:
@@ -417,14 +628,14 @@ bg:
     analytics_desc_list_3:
     analytics_desc_list_4:
     analytics_trackers:
-    and: "и"
+    and: и
     approve:
     approved_at:
     approver:
-    are_you_sure: "Сигурни ли сте"
-    are_you_sure_delete: "Сигурни ли сте, че искате да изтриете този запис?"
+    are_you_sure: Сигурни ли сте
+    are_you_sure_delete: Сигурни ли сте, че искате да изтриете този запис?
     associated_adjustment_closed:
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure:
     authorized:
     auto_capture:
@@ -445,93 +656,93 @@ bg:
     balance_due:
     base_amount:
     base_percent:
-    bill_address: "Адрес на плащане"
-    billing: "Плащане"
-    billing_address: "Адрес на плащане"
-    both: "И двете"
+    bill_address: Адрес на плащане
+    billing: Плащане
+    billing_address: Адрес на плащане
+    both: И двете
     calculated_reimbursements:
-    calculator: "Калкулатор"
+    calculator: Калкулатор
     calculator_settings_warning:
     cancel:
     canceled_at:
     canceler:
     cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: "Не може да платите без да сте избрали начин на плащане"
-    cannot_create_returns: "Не можете да върнете стока обратно преди поръчката да е пусната."
-    cannot_perform_operation: "Желаното действие не може да бъде извършено."
-    cannot_set_shipping_method_without_address: "Начин за доставка не може да бъде зададен без данни на клиента."
-    capture: "Картина"
+    cannot_create_payment_without_payment_methods: Не може да платите без да сте избрали начин на плащане
+    cannot_create_returns: Не можете да върнете стока обратно преди поръчката да е пусната.
+    cannot_perform_operation: Желаното действие не може да бъде извършено.
+    cannot_set_shipping_method_without_address: Начин за доставка не може да бъде зададен без данни на клиента.
+    capture: Картина
     capture_events:
-    card_code: "Код на карта"
-    card_number: "Номер на карта"
+    card_code: Код на карта
+    card_number: Номер на карта
     card_type:
-    card_type_is: "Видът на картата"
-    cart: "Кошница"
+    card_type_is: Видът на картата
+    cart: Кошница
     cart_subtotal:
-    categories: "Категории"
-    category: "Категория"
+    categories: Категории
+    category: Категория
     charged:
     check_for_spree_alerts:
-    checkout: "Плащане"
-    choose_a_customer: "Избери клиент"
+    checkout: Плащане
+    choose_a_customer: Избери клиент
     choose_a_taxon_to_sort_products_for:
-    choose_currency: "Избери валута"
+    choose_currency: Избери валута
     choose_dashboard_locale:
     choose_location:
-    city: "Град"
+    city: Град
     clear_cache:
     clear_cache_ok:
     clear_cache_warning:
     click_and_drag_on_the_products_to_sort_them:
-    clone: "Клонирай"
-    close: "Затвори"
-    close_all_adjustments: "Затвори всички промени"
-    code: "Код"
-    company: "Компания"
-    complete: "Завърши"
-    configuration: "Конфигурация"
-    configurations: "Конфигурации"
-    confirm: "Потвърди"
-    confirm_delete: "Потвърди изтриване"
-    confirm_password: "Потвърди парола"
-    continue: "Продължи"
-    continue_shopping: "Продължи пазаруването"
-    cost_currency: "Валута"
+    clone: Клонирай
+    close: Затвори
+    close_all_adjustments: Затвори всички промени
+    code: Код
+    company: Компания
+    complete: Завърши
+    configuration: Конфигурация
+    configurations: Конфигурации
+    confirm: Потвърди
+    confirm_delete: Потвърди изтриване
+    confirm_password: Потвърди парола
+    continue: Продължи
+    continue_shopping: Продължи пазаруването
+    cost_currency: Валута
     cost_price:
     could_not_connect_to_jirafe:
     could_not_create_customer_return:
     could_not_create_stock_movement:
     count_on_hand:
     countries:
-    country: "Страна"
+    country: Страна
     country_based:
-    country_name: "Име"
+    country_name: Име
     country_names:
       CA:
       FRA:
       ITA:
       US:
-    coupon: "Ваучер"
-    coupon_code: "Код на ваучер"
-    coupon_code_already_applied: "Този код вече е използван за тази доставка."
-    coupon_code_applied: "Този код бе успешно приложен към вашата поръчка"
-    coupon_code_better_exists: "Предишният ваучер предоставя по-добри условия"
-    coupon_code_expired: "Този ваучер е изтекъл"
-    coupon_code_max_usage: "Употребата на ваучери преминава лимита."
-    coupon_code_not_eligible: "Този код не е валиден за тази поръчка."
-    coupon_code_not_found: "Въведеният код не е валиден. Опитайте отново."
+    coupon: Ваучер
+    coupon_code: Код на ваучер
+    coupon_code_already_applied: Този код вече е използван за тази доставка.
+    coupon_code_applied: Този код бе успешно приложен към вашата поръчка
+    coupon_code_better_exists: Предишният ваучер предоставя по-добри условия
+    coupon_code_expired: Този ваучер е изтекъл
+    coupon_code_max_usage: Употребата на ваучери преминава лимита.
+    coupon_code_not_eligible: Този код не е валиден за тази поръчка.
+    coupon_code_not_found: Въведеният код не е валиден. Опитайте отново.
     coupon_code_unknown_error:
-    create: "Създай"
-    create_a_new_account: "Създай нов акаунт"
+    create: Създай
+    create_a_new_account: Създай нов акаунт
     create_new_order:
     create_reimbursement:
-    created_at: "Създаден на"
-    credit: "Кредит"
-    credit_card: "Кредитна карта"
-    credit_cards: "Кредитни карти"
-    credit_owed: "Дължима сума по кредит"
+    created_at: Създаден на
+    credit: Кредит
+    credit_card: Кредитна карта
+    credit_cards: Кредитни карти
+    credit_owed: Дължима сума по кредит
     credits:
-    currency: "Валута"
+    currency: Валута
     currency_decimal_mark:
     currency_settings:
     currency_symbol_position:
@@ -567,7 +778,7 @@ bg:
     default_refund_amount:
     default_tax:
     default_tax_zone:
-    delete: "Изтрий"
+    delete: Изтрий
     deleted_variants_present:
     delivery:
     depth:
@@ -602,232 +813,232 @@ bg:
     email:
     empty:
     empty_cart:
-    enable_mail_delivery: "Позволи изпращане по поща"
-    end: "Край"
-    ending_in: "Приключване в"
-    environment: "среда"
-    error: "грешка"
+    enable_mail_delivery: Позволи изпращане по поща
+    end: Край
+    ending_in: Приключване в
+    environment: среда
+    error: грешка
     errors:
       messages:
-        could_not_create_taxon: "Провал в създаването на група"
-        no_payment_methods_available: "Няма методи за заплащане конфигурирани за тази среда"
-        no_shipping_methods_available: "Няма възможност за изпращане по куриер до избраната локация, моля сменете адреса си и пробвайте пак."
+        could_not_create_taxon: Провал в създаването на група
+        no_payment_methods_available: Няма методи за заплащане конфигурирани за тази среда
+        no_shipping_methods_available: Няма възможност за изпращане по куриер до избраната локация, моля сменете адреса си и пробвайте пак.
     errors_prohibited_this_record_from_being_saved:
-      one: "Грешка попречи на тези дани да бъдат записани."
+      one: Грешка попречи на тези дани да бъдат записани.
       other: "%{count} errors prohibited this record from being saved"
-    event: "Събитие"
+    event: Събитие
     events:
       spree:
         cart:
-          add: "Добави към количка"
+          add: Добави към количка
         checkout:
-          coupon_code_added: "Купон за остъпка прибавен"
+          coupon_code_added: Купон за остъпка прибавен
         content:
-          visited: "Посети статична страница с данни"
+          visited: Посети статична страница с данни
         order:
-          contents_changed: "Реда на съдържанието променее"
-        page_view: "Статична страница видяна"
+          contents_changed: Реда на съдържанието променее
+        page_view: Статична страница видяна
         user:
-          signup: "Потребителски вход"
+          signup: Потребителски вход
     exceptions:
-      count_on_hand_setter: "Грешка при ръчното обновяването на count_on_hand, тъй като бе обновено от повик към recalculate_count_on_hand. Моля използвайте`update_column(:count_on_hand, value)` вместо това."
+      count_on_hand_setter: Грешка при ръчното обновяването на count_on_hand, тъй като бе обновено от повик към recalculate_count_on_hand. Моля използвайте`update_column(:count_on_hand, value)` вместо това.
     exchange_for:
     excl:
     existing_shipments:
     expedited_exchanges_warning:
-    expiration: "Срок на годност"
-    extension: "Удъжения"
+    expiration: Срок на годност
+    extension: Удъжения
     failed_payment_attempts:
-    filename: "Име на файл"
-    fill_in_customer_info: "Моля попълнете потребителска информация"
-    filter_results: "Филтриране на резултатите"
-    finalize: "Финализирай"
+    filename: Име на файл
+    fill_in_customer_info: Моля попълнете потребителска информация
+    filter_results: Филтриране на резултатите
+    finalize: Финализирай
     finalized:
     find_a_taxon:
-    first_item: "Цена на първи предмет"
-    first_name: "Първо име"
-    first_name_begins_with: "Първо име  започва с"
-    flat_percent: "Плосък процент"
-    flat_rate_per_order: "Пропорционална такса (на поръчка)"
-    flexible_rate: "Гъвкав курс"
-    forgot_password: "Забравена парола"
-    free_shipping: "Безплатна доставка"
+    first_item: Цена на първи предмет
+    first_name: Първо име
+    first_name_begins_with: Първо име  започва с
+    flat_percent: Плосък процент
+    flat_rate_per_order: Пропорционална такса (на поръчка)
+    flexible_rate: Гъвкав курс
+    forgot_password: Забравена парола
+    free_shipping: Безплатна доставка
     free_shipping_amount:
-    front_end: "Преден Край"
-    gateway: "Портал"
-    gateway_config_unavailable: "Порталът не е на разположение за тази среда"
-    gateway_error: "Грешка в портала"
-    general: "Генерален"
-    general_settings: "Генерални настройки"
+    front_end: Преден Край
+    gateway: Портал
+    gateway_config_unavailable: Порталът не е на разположение за тази среда
+    gateway_error: Грешка в портала
+    general: Генерален
+    general_settings: Генерални настройки
     google_analytics: Google Аналитика
-    google_analytics_id: "Идентифиционен номер на аналитиката"
-    guest_checkout: "Каса за гости"
-    guest_user_account: "Маркирай като гост."
-    has_no_shipped_units: "Няма пратени единици."
-    height: "Височина"
+    google_analytics_id: Идентифиционен номер на аналитиката
+    guest_checkout: Каса за гости
+    guest_user_account: Маркирай като гост.
+    has_no_shipped_units: Няма пратени единици.
+    height: Височина
     hide_cents: Hide pence
-    home: "Дом"
+    home: Дом
     i18n:
-      available_locales: "Достъпни места"
-      language: "Език"
-      localization_settings: "Настройки за локализация"
-      this_file_language: "Български (БГ)"
-    icon: "Икона"
+      available_locales: Достъпни места
+      language: Език
+      localization_settings: Настройки за локализация
+      this_file_language: Български (БГ)
+    icon: Икона
     identifier:
-    image: "Образ"
-    images: "Образи"
+    image: Образ
+    images: Образи
     implement_eligible_for_return:
     implement_requires_manual_intervention:
     inactive:
     incl:
-    included_in_price: "Включено в цената"
-    included_price_validation: "Не може да бъде избрано докато не изберете подходяща област"
+    included_in_price: Включено в цената
+    included_price_validation: Не може да бъде избрано докато не изберете подходяща област
     incomplete:
     info_number_of_skus_not_shown:
     info_product_has_multiple_skus:
     instructions_to_reset_password:
-    insufficient_stock: "Недостатъчно количество стока в наличност, само %{on_hand} остават."
+    insufficient_stock: Недостатъчно количество стока в наличност, само %{on_hand} остават.
     insufficient_stock_lines_present:
-    intercept_email_address: "Пресрещане на имеил адрес"
-    intercept_email_instructions: "Отемни сегашните имеил приемници и замени с този адрес."
-    internal_name: "Вътрешно име."
+    intercept_email_address: Пресрещане на имеил адрес
+    intercept_email_instructions: Отемни сегашните имеил приемници и замени с този адрес.
+    internal_name: Вътрешно име.
     invalid_credit_card:
     invalid_exchange_variant:
-    invalid_payment_provider: "Невалиден разплащателен метод."
-    invalid_promotion_action: "Невалидна промоционална дейност."
-    invalid_promotion_rule: "Невалидно промоционално правило."
-    inventory: "Инвентар"
-    inventory_adjustment: "Наглацяне на инвентара"
-    inventory_error_flash_for_insufficient_quantity: "Количествата на предмет във вашата кошница се изчерпаха."
+    invalid_payment_provider: Невалиден разплащателен метод.
+    invalid_promotion_action: Невалидна промоционална дейност.
+    invalid_promotion_rule: Невалидно промоционално правило.
+    inventory: Инвентар
+    inventory_adjustment: Наглацяне на инвентара
+    inventory_error_flash_for_insufficient_quantity: Количествата на предмет във вашата кошница се изчерпаха.
     inventory_state:
-    is_not_available_to_shipment_address: "Не е достъпно до адрес на доставка"
+    is_not_available_to_shipment_address: Не е достъпно до адрес на доставка
     iso_name: Iso Име
-    item: "Предмет"
-    item_description: "Описание на предмет"
-    item_total: "Количество"
+    item: Предмет
+    item_description: Описание на предмет
+    item_total: Количество
     item_total_rule:
       operators:
-        gt: "повече ог"
-        gte: "повече от или равно на"
+        gt: повече ог
+        gte: повече от или равно на
         lt:
         lte:
-    items_cannot_be_shipped: "Нямаме възможносттта да доставим тези предмети до този адрес. Моля изберете друг адрес на доставка."
+    items_cannot_be_shipped: Нямаме възможносттта да доставим тези предмети до този адрес. Моля изберете друг адрес на доставка.
     items_in_rmas:
     items_reimbursed:
     items_to_be_reimbursed:
-    jirafe: "Жираф"
+    jirafe: Жираф
     landing_page_rule:
-      path: "Път"
-    last_name: "Последно име"
-    last_name_begins_with: "Последното име започва с"
-    learn_more: "Научи повече"
+      path: Път
+    last_name: Последно име
+    last_name_begins_with: Последното име започва с
+    learn_more: Научи повече
     lifetime_stats:
     line_item_adjustments:
-    list: "Списък"
-    loading: "Зареждане"
-    locale_changed: "Местоположение сменено"
-    location: "Местоположение"
-    lock: "Закючи"
+    list: Списък
+    loading: Зареждане
+    locale_changed: Местоположение сменено
+    location: Местоположение
+    lock: Закючи
     log_entries:
-    logged_in_as: "Влезте като"
-    logged_in_succesfully: "Успешно влизане"
-    logged_out: "Успешен изход."
-    login: "Вход"
-    login_as_existing: "Влезте като настоящ клиент"
-    login_failed: "Неуспешно за установяване на автентичността."
-    login_name: "Потребителско име"
-    logout: "Изход"
+    logged_in_as: Влезте като
+    logged_in_succesfully: Успешно влизане
+    logged_out: Успешен изход.
+    login: Вход
+    login_as_existing: Влезте като настоящ клиент
+    login_failed: Неуспешно за установяване на автентичността.
+    login_name: Потребителско име
+    logout: Изход
     logs:
-    look_for_similar_items: "Потърси за подобни предмети"
-    make_refund: "Въстановяване на сума"
+    look_for_similar_items: Потърси за подобни предмети
+    make_refund: Въстановяване на сума
     make_sure_the_above_reimbursement_amount_is_correct:
     manage_promotion_categories:
     manage_variants:
     manual_intervention_required:
-    master_price: "Главна сума"
+    master_price: Главна сума
     match_choices:
-      all: "Всички"
-      none: "Никои"
-    max_items: "Максимален брой предмети"
+      all: Всички
+      none: Никои
+    max_items: Максимален брой предмети
     member_since:
     memo:
-    meta_description: "Описание"
-    meta_keywords: "Ключови думи"
+    meta_description: Описание
+    meta_keywords: Ключови думи
     meta_title:
-    metadata: "Дата"
-    minimal_amount: "Минимално количество"
-    month: "Месец"
-    more: "Още"
-    move_stock_between_locations: "Премести стока между местоположения."
-    my_account: "Моя профил"
-    my_orders: "Моите поръчки"
-    name: "Име"
+    metadata: Дата
+    minimal_amount: Минимално количество
+    month: Месец
+    more: Още
+    move_stock_between_locations: Премести стока между местоположения.
+    my_account: Моя профил
+    my_orders: Моите поръчки
+    name: Име
     name_on_card:
-    name_or_sku: "Име или Идентификационен номер на продукт"
-    new: "Име"
-    new_adjustment: "Ново нагалсяне"
+    name_or_sku: Име или Идентификационен номер на продукт
+    new: Име
+    new_adjustment: Ново нагалсяне
     new_country:
-    new_customer: "Нов клиент"
+    new_customer: Нов клиент
     new_customer_return:
-    new_image: "Нов образ"
-    new_option_type: "Нов метод за настойки"
-    new_order: "Нова поръчка"
-    new_order_completed: "Нава поръчка завършена"
-    new_payment: "Ново заплащане"
-    new_payment_method: "Нов метод за заплащане"
-    new_product: "Нов продукт"
-    new_promotion: "Нова промоция"
+    new_image: Нов образ
+    new_option_type: Нов метод за настойки
+    new_order: Нова поръчка
+    new_order_completed: Нава поръчка завършена
+    new_payment: Ново заплащане
+    new_payment_method: Нов метод за заплащане
+    new_product: Нов продукт
+    new_promotion: Нова промоция
     new_promotion_category:
-    new_property: "Ново свойство"
-    new_prototype: "Нов прототип"
+    new_property: Ново свойство
+    new_prototype: Нов прототип
     new_refund:
     new_refund_reason:
-    new_return_authorization: "Нов метод за оторизиране на връщане"
+    new_return_authorization: Нов метод за оторизиране на връщане
     new_rma_reason:
     new_shipment_at_location:
-    new_shipping_category: "Нова категория за доставки"
-    new_shipping_method: "Нов метод за доставки"
-    new_state: "Ново състояние"
-    new_stock_location: "Ново местоположение на стока"
-    new_stock_movement: "Ново преместване на стока"
-    new_stock_transfer: "Нов трансфер на стока"
-    new_tax_category: "Нова категория такси"
-    new_tax_rate: "Новa dанъчна ставка"
-    new_taxon: "Нов таксон"
-    new_taxonomy: "Нова таксономия"
-    new_tracker: "Нов тракер"
-    new_user: "Нов потребител"
-    new_variant: "Нов вариант"
-    new_zone: "Нова зона"
-    next: "Следващ"
-    no_actions_added: "Няма избрани дейности"
+    new_shipping_category: Нова категория за доставки
+    new_shipping_method: Нов метод за доставки
+    new_state: Ново състояние
+    new_stock_location: Ново местоположение на стока
+    new_stock_movement: Ново преместване на стока
+    new_stock_transfer: Нов трансфер на стока
+    new_tax_category: Нова категория такси
+    new_tax_rate: Новa dанъчна ставка
+    new_taxon: Нов таксон
+    new_taxonomy: Нова таксономия
+    new_tracker: Нов тракер
+    new_user: Нов потребител
+    new_variant: Нов вариант
+    new_zone: Нова зона
+    next: Следващ
+    no_actions_added: Няма избрани дейности
     no_payment_found:
-    no_pending_payments: "Няма настоящи плащания"
-    no_products_found: "Няма открити пордукти"
+    no_pending_payments: Няма настоящи плащания
+    no_products_found: Няма открити пордукти
     no_resource_found:
-    no_results: "Няма резилтати"
+    no_results: Няма резилтати
     no_returns_found:
-    no_rules_added: "Никакви правила прибавени"
+    no_rules_added: Никакви правила прибавени
     no_shipping_method_selected:
     no_state_changes:
-    no_tracking_present: "Няма информация за следене"
-    none: "Нищо"
+    no_tracking_present: Няма информация за следене
+    none: Нищо
     none_selected:
-    normal_amount: "Нормално количество"
-    not: "не"
-    not_available: "Няма в наличност"
-    not_enough_stock: "Няма достатъчно налични количества в стока да се извърши поръчката."
+    normal_amount: Нормално количество
+    not: не
+    not_available: Няма в наличност
+    not_enough_stock: Няма достатъчно налични количества в стока да се извърши поръчката.
     not_found: "%{resource} is not found"
     note:
     notice_messages:
-      product_cloned: "Продуктът бе дупликиран"
-      product_deleted: "Продуктът беше изтрит"
-      product_not_cloned: "Продуктът не бе клониран"
-      product_not_deleted: "Продуктът не можеше да бъде изтрит"
-      variant_deleted: "Вариантът бе изтрит"
-      variant_not_deleted: "Вариантът не можеше да бъде изтрит"
+      product_cloned: Продуктът бе дупликиран
+      product_deleted: Продуктът беше изтрит
+      product_not_cloned: Продуктът не бе клониран
+      product_not_deleted: Продуктът не можеше да бъде изтрит
+      variant_deleted: Вариантът бе изтрит
+      variant_not_deleted: Вариантът не можеше да бъде изтрит
     num_orders:
-    on_hand: "Наличност"
+    on_hand: Наличност
     open:
     open_all_adjustments:
     option_type:
@@ -863,6 +1074,8 @@ bg:
         subtotal:
         thanks:
         total:
+      inventory_cancellation:
+        dear_customer:
     order_not_found:
     order_number:
     order_processed_successfully:
@@ -870,90 +1083,90 @@ bg:
     order_state:
       address:
       awaiting_return:
-      canceled: "отказано"
-      cart: "количка"
-      complete: "завършено"
-      confirm: "потвърди"
+      canceled: отказано
+      cart: количка
+      complete: завършено
+      confirm: потвърди
       considered_risky:
-      delivery: "доставка"
-      payment: "плащане"
-      resumed: "възобновено"
-      returned: "върнато"
-    order_summary: "Преглед на поръчка"
+      delivery: доставка
+      payment: плащане
+      resumed: възобновено
+      returned: върнато
+    order_summary: Преглед на поръчка
     order_sure_want_to:
-    order_total: "Цялостна стойност"
-    order_updated: "Поръчката бе обновена"
-    orders: "Поръчки"
+    order_total: Цялостна стойност
+    order_updated: Поръчката бе обновена
+    orders: Поръчки
     other_items_in_other:
-    out_of_stock: "Не е в наличност"
-    overview: "Преглед"
+    out_of_stock: Не е в наличност
+    overview: Преглед
     package_from: package from
     pagination:
       next_page: next page »
       previous_page: "« previous page"
       truncate: "…"
-    password: "Парола"
-    paste: "Постави"
-    path: "Път"
-    pay: "Плати"
-    payment: "Плащане"
+    password: Парола
+    paste: Постави
+    path: Път
+    pay: Плати
+    payment: Плащане
     payment_could_not_be_created:
     payment_identifier:
-    payment_information: "Информация за плащане"
-    payment_method: "Начин на плащане"
+    payment_information: Информация за плащане
+    payment_method: Начин на плащане
     payment_method_not_supported:
-    payment_methods: "Методи на плащане"
+    payment_methods: Методи на плащане
     payment_processing_failed:
     payment_processor_choose_banner_text:
     payment_processor_choose_link:
-    payment_state: "Статус на плащането"
+    payment_state: Статус на плащането
     payment_states:
       balance_due:
       checkout:
       completed:
       credit_owed:
-      failed: "провалено"
+      failed: провалено
       paid:
       pending:
       processing:
       void:
-    payment_updated: "Плащането бе обновено"
-    payments: "Плащания"
+    payment_updated: Плащането бе обновено
+    payments: Плащания
     pending:
-    percent: "Процент"
+    percent: Процент
     percent_per_item:
     permalink: Permalink
-    phone: "Телефон"
-    place_order: "Направи поръчка"
-    please_define_payment_methods: "Моля, първо дефинирайте методи за плащане."
+    phone: Телефон
+    place_order: Направи поръчка
+    please_define_payment_methods: Моля, първо дефинирайте методи за плащане.
     populate_get_error:
-    powered_by: "Уебсайтът е задвижван от"
+    powered_by: Уебсайтът е задвижван от
     pre_tax_amount:
     pre_tax_refund_amount:
     pre_tax_total:
     preferred_reimbursement_type:
     presentation:
-    previous: "Предходен"
+    previous: Предходен
     previous_state_missing:
-    price: "Цена"
+    price: Цена
     price_range:
     price_sack:
-    process: "Продукт"
+    process: Продукт
     product: Product
-    product_details: "Информация за продукта"
+    product_details: Информация за продукта
     product_has_no_description:
     product_not_available_in_this_currency:
     product_properties:
     product_rule:
-      choose_products: "Избери продукти"
+      choose_products: Избери продукти
       label:
-      match_all: "всички"
-      match_any: "поне един"
+      match_all: всички
+      match_any: поне един
       match_none:
       product_source:
-        group: "От продуктова група"
-        manual: "Избери ръчно"
-    products: "Продукти"
+        group: От продуктова група
+        manual: Избери ръчно
+    products: Продукти
     promotion:
     promotion_action:
     promotion_action_types:
@@ -983,8 +1196,8 @@ bg:
         description:
         name:
       landing_page:
-        description: "Потребителят трябва да е посетил определена страница"
-        name: "Целева страница"
+        description: Потребителят трябва да е посетил определена страница
+        name: Целева страница
       one_use_per_user:
         description:
         name:
@@ -992,17 +1205,17 @@ bg:
         description:
         name:
       product:
-        description: "Поръчката има следният/ите продукт(и)"
-        name: "Продукт(и)"
+        description: Поръчката има следният/ите продукт(и)
+        name: Продукт(и)
       taxon:
         description:
         name:
       user:
-        description: "Достъпно само за определени потребители"
-        name: "Потребител"
+        description: Достъпно само за определени потребители
+        name: Потребител
       user_logged_in:
-        description: "Достъпно само за потребители, които са влезли в сайта"
-        name: "Потребителят е влязал в сайта"
+        description: Достъпно само за потребители, които са влезли в сайта
+        name: Потребителят е влязал в сайта
     promotion_uses:
     promotionable:
     promotions:
@@ -1010,19 +1223,19 @@ bg:
     properties:
     property:
     prototype:
-    prototypes: "Прототипи"
-    provider: "Доставчик"
+    prototypes: Прототипи
+    provider: Доставчик
     provider_settings_warning:
-    qty: "Кол."
-    quantity: "Количество"
-    quantity_returned: "Количество върнато"
-    quantity_shipped: "Количество пратено"
+    qty: Кол.
+    quantity: Количество
+    quantity_returned: Количество върнато
+    quantity_shipped: Количество пратено
     quick_search:
     rate: Rate
-    reason: "Причина"
-    receive: "получи"
+    reason: Причина
+    receive: получи
     receive_stock:
-    received: "Получено"
+    received: Получено
     reception_status:
     reference:
     refund:
@@ -1030,8 +1243,8 @@ bg:
     refund_reasons:
     refunded_amount:
     refunds:
-    register: "Регистрирай се като нов потребител"
-    registration: "Регистрация"
+    register: Регистрирай се като нов потребител
+    registration: Регистрация
     reimburse:
     reimbursed:
     reimbursement:
@@ -1053,17 +1266,17 @@ bg:
     reimbursements:
     reject:
     rejected:
-    remember_me: "Запомни ме"
-    remove: "Премахни"
-    rename: "Преименувай"
+    remember_me: Запомни ме
+    remove: Премахни
+    rename: Преименувай
     report:
     reports:
-    resend: "Препрати"
-    reset_password: "Възстанови паролата"
+    resend: Препрати
+    reset_password: Възстанови паролата
     response_code:
-    resume: "продължи"
-    resumed: "Продължено"
-    return: "върни"
+    resume: продължи
+    resumed: Продължено
+    return: върни
     return_authorization:
     return_authorization_reasons:
     return_authorization_updated:
@@ -1085,20 +1298,20 @@ bg:
     rma_credit:
     rma_number:
     rma_value:
-    roles: "Роли"
-    rules: "ПРавила"
+    roles: Роли
+    rules: ПРавила
     safe:
     sales_total:
     sales_total_description:
     sales_totals:
     save_and_continue:
     save_my_address:
-    say_no: "Не"
-    say_yes: "Да"
+    say_no: Не
+    say_yes: Да
     scope: Scope
-    search: "Търси"
-    search_results: "Резултати за '%{keywords}'"
-    searching: "Търсене"
+    search: Търси
+    search_results: Резултати за '%{keywords}'
+    searching: Търсене
     secure_connection_type:
     security_settings:
     select:
@@ -1108,40 +1321,40 @@ bg:
     select_stock:
     send_copy_of_all_mails_to:
     send_mails_as:
-    server: "Сървър"
-    server_error: "Сървърът върна грешла"
-    settings: "Настройки"
-    ship: "прати"
-    ship_address: "Адрес"
-    ship_total: "Общо"
-    shipment: "Доставка"
+    server: Сървър
+    server_error: Сървърът върна грешла
+    settings: Настройки
+    ship: прати
+    ship_address: Адрес
+    ship_total: Общо
+    shipment: Доставка
     shipment_adjustments:
     shipment_details:
     shipment_mailer:
       shipped_email:
-        dear_customer: "Драги клиент"
-        instructions: "Вашата поръчка е пусната"
-        shipment_summary: "Обзор на поръчката"
+        dear_customer: Драги клиент
+        instructions: Вашата поръчка е пусната
+        shipment_summary: Обзор на поръчката
         subject: Shipment  Нотификация
-        thanks: "Благодарим Ви!"
+        thanks: Благодарим Ви!
         track_information:
         track_link:
-    shipment_state: "Положение на пратката"
+    shipment_state: Положение на пратката
     shipment_states:
-      backorder: "неизпълнена"
+      backorder: неизпълнена
       canceled:
-      partial: "частична"
-      pending: "изчакваща"
-      ready: "готова"
-      shipped: "пратена"
+      partial: частична
+      pending: изчакваща
+      ready: готова
+      shipped: пратена
     shipment_transfer_error:
     shipment_transfer_success:
     shipments:
-    shipped: "пратена"
-    shipping: "Пратки"
-    shipping_address: "Адрес на доставка"
-    shipping_categories: "Катергории за доставки"
-    shipping_category: "Категория за доставка"
+    shipped: пратена
+    shipping: Пратки
+    shipping_address: Адрес на доставка
+    shipping_categories: Катергории за доставки
+    shipping_category: Категория за доставка
     shipping_flat_rate_per_item:
     shipping_flat_rate_per_order:
     shipping_flexible_rate:
@@ -1238,20 +1451,20 @@ bg:
     tax_rate_amount_explanation:
     tax_rates:
     taxon:
-    taxon_edit: "Промени таксон"
-    taxon_placeholder: "Добави таксон"
+    taxon_edit: Промени таксон
+    taxon_placeholder: Добави таксон
     taxon_rule:
       choose_taxons:
       label:
       match_all:
       match_any:
-    taxonomies: "Таксономии"
-    taxonomy: "Таксономия"
-    taxonomy_edit: "Промени таксономия"
+    taxonomies: Таксономии
+    taxonomy: Таксономия
+    taxonomy_edit: Промени таксономия
     taxonomy_tree_error:
     taxonomy_tree_instruction:
-    taxons: "Таксони"
-    test: "Тест"
+    taxons: Таксони
+    test: Тест
     test_mailer:
       test_email:
         greeting:
@@ -1266,9 +1479,9 @@ bg:
     tiered_flat_rate:
     tiered_percent:
     tiers:
-    time: "Време"
-    to_add_variants_you_must_first_define: "За да добавите варианти, трябва да дефинирате"
-    total: "Общо"
+    time: Време
+    to_add_variants_you_must_first_define: За да добавите варианти, трябва да дефинирате
+    total: Общо
     total_per_item:
     total_pre_tax_refund:
     total_price:
@@ -1280,51 +1493,75 @@ bg:
     tracking_url_placeholder:
     transaction_id:
     transfer_from_location:
-    transfer_stock: "Трансферирай запаси"
-    transfer_to_location: "Трансферирай към"
-    tree: "Дърво"
-    type: "Тип"
-    type_to_search: "Тип на търсене"
+    transfer_stock: Трансферирай запаси
+    transfer_to_location: Трансферирай към
+    tree: Дърво
+    type: Тип
+    type_to_search: Тип на търсене
     unable_to_connect_to_gateway:
     unable_to_create_reimbursements:
-    under_price: "Под %{price}"
-    unlock: "Отключи"
-    unrecognized_card_type: "Неразпознат тип карта"
-    unshippable_items: "Неизпращаеми артикули"
-    update: "Обнови"
-    updating: "Обновване"
-    usage_limit: "Лимит на ползване"
+    under_price: Под %{price}
+    unlock: Отключи
+    unrecognized_card_type: Неразпознат тип карта
+    unshippable_items: Неизпращаеми артикули
+    update: Обнови
+    updating: Обновване
+    usage_limit: Лимит на ползване
     use_app_default:
-    use_billing_address: "Използвай адрес за фактуриране"
-    use_new_cc: "Използвай нова карта"
-    use_s3: "Използвай Amazon S3 за изображения"
+    use_billing_address: Използвай адрес за фактуриране
+    use_new_cc: Използвай нова карта
+    use_s3: Използвай Amazon S3 за изображения
     user: User
     user_rule:
-      choose_users: "Изберете потребители"
-    users: "Потребители"
+      choose_users: Изберете потребители
+    users: Потребители
     validation:
-      cannot_be_less_than_shipped_units: "не може да бъде по-малко от броя на изпратените единици"
+      cannot_be_less_than_shipped_units: не може да бъде по-малко от броя на изпратените единици
       cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock: "е над наличността. Моля, уверете че уговорните покупки имат валидна стойност."
-      is_too_large: "е прекалено голяма --  наличността не достига!"
-      must_be_int: "трябва да е цяло число"
-      must_be_non_negative: "трябва да е позитивна стойност"
+      exceeds_available_stock: е над наличността. Моля, уверете че уговорните покупки имат валидна стойност.
+      is_too_large: е прекалено голяма --  наличността не достига!
+      must_be_int: трябва да е цяло число
+      must_be_non_negative: трябва да е позитивна стойност
       unpaid_amount_not_zero:
-    value: "Стойност"
-    variant: "Вариант"
-    variant_placeholder: "Избери вариант"
-    variants: "Варианти"
-    version: "Версия"
-    void: "Откажи"
-    weight: "Тежест"
-    what_is_a_cvv: "Какво е CVV код?"
-    what_is_this: "Какво е това?"
-    width: "Ширина"
-    year: "Година"
-    you_have_no_orders_yet: "Все още нямате поръчки"
-    your_cart_is_empty: "Вашата кошница е празна"
-    your_order_is_empty_add_product: "Вашата кошница е празна, моля добаете артикули"
-    zip: "пощ. кид"
-    zipcode: "пощ. код"
-    zone: "Зона"
-    zones: "Зони"
+    value: Стойност
+    variant: Вариант
+    variant_placeholder: Избери вариант
+    variants: Варианти
+    version: Версия
+    void: Откажи
+    weight: Тежест
+    what_is_a_cvv: Какво е CVV код?
+    what_is_this: Какво е това?
+    width: Ширина
+    year: Година
+    you_have_no_orders_yet: Все още нямате поръчки
+    your_cart_is_empty: Вашата кошница е празна
+    your_order_is_empty_add_product: Вашата кошница е празна, моля добаете артикули
+    zip: пощ. кид
+    zipcode: пощ. код
+    zone: Зона
+    zones: Зони
+    canceled: отказано
+    cannot_create_payment_link: Моля, първо дефинирайте методи за плащане.
+    inventory_states:
+      canceled: отказано
+      returned: върнато
+      shipped: пратена
+    no_resource_found_link: Добави едно
+    number: Номер
+    store_credit:
+      display_action:
+        adjustment: Поправка
+        credit: Кредит
+        void: Кредит
+        admin:
+          authorize:
+    store_credit_category:
+      default:
+  activemodel:
+    attributes:
+      spree/order_cancellations:
+        quantity: Количество
+        state:
+        shipment: Доставка
+        cancel: Отмени


### PR DESCRIPTION
Recent changes made to admin translations in solidus moved many of the keys. This was done to better use the ActiveModel translation conventions.

I wrote a [script](https://github.com/StemboltHQ/solidus_i18n_convert) that scans through the locale files in solidus_i18n looking for missing keys when compared to `en.yml` in core. Since these translations are just moved, the script attempts to make the same moves in this locale as were made for english.

Reviews would be appreciated to find any blatant mistranslations.
