### PR TITLE
Convert fr translations from solidus 1.2 -> 1.3

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,57 +1,58 @@
+---
 fr:
   date:
     abbr_day_names:
-      - dim
-      - lun
-      - mar
-      - mer
-      - jeu
-      - ven
-      - sam
+    - dim
+    - lun
+    - mar
+    - mer
+    - jeu
+    - ven
+    - sam
     abbr_month_names:
-      -
-      - jan.
-      - fév.
-      - mar.
-      - avr.
-      - mai
-      - juin
-      - juil.
-      - août
-      - sept.
-      - oct.
-      - nov.
-      - déc.
+    -
+    - jan.
+    - fév.
+    - mar.
+    - avr.
+    - mai
+    - juin
+    - juil.
+    - août
+    - sept.
+    - oct.
+    - nov.
+    - déc.
     day_names:
-      - dimanche
-      - lundi
-      - mardi
-      - mercredi
-      - jeudi
-      - vendredi
-      - samedi
+    - dimanche
+    - lundi
+    - mardi
+    - mercredi
+    - jeudi
+    - vendredi
+    - samedi
     formats:
       default: "%d/%m/%Y"
       short: "%e %b"
       long: "%e %B %Y"
     month_names:
-      -
-      - janvier
-      - février
-      - mars
-      - avril
-      - mai
-      - juin
-      - juillet
-      - août
-      - septembre
-      - octobre
-      - novembre
-      - décembre
+    -
+    - janvier
+    - février
+    - mars
+    - avril
+    - mai
+    - juin
+    - juillet
+    - août
+    - septembre
+    - octobre
+    - novembre
+    - décembre
     order:
-      - :day
-      - :month
-      - :year
+    - :day
+    - :month
+    - :year
     datetime:
       distance_in_words:
         about_x_hours:
@@ -204,10 +205,6 @@ fr:
         long: "%A %d %B %Y %Hh%M"
         short: "%d %b %Hh%M"
       pm: pm
-
-
-#SPREE TRANSLATION
-
   activerecord:
     attributes:
       spree/address:
@@ -220,6 +217,7 @@ fr:
         phone: Téléphone
         state: Province / Région / État
         zipcode: Code Postal
+        company: Entreprise
       spree/calculator/tiered_flat_rate:
         preferred_base_amount: Montant de base
         preferred_tiers: Tiers
@@ -232,6 +230,7 @@ fr:
         iso_name: Nom ISO
         name: Nom
         numcode: Code ISO
+        states_required: État / province obligatoire
       spree/credit_card:
         base:
         cc_type: Type
@@ -240,11 +239,16 @@ fr:
         number: Numéro
         verification_value: Code de sécurité
         year: Année
+        card_code: Code de la carte
+        expiration: Expiration
       spree/inventory_unit:
-        state: Province / Région / État
+        state: État
       spree/line_item:
         price: Prix
         quantity: Quantité
+        description: Description de l'article
+        name: Nom
+        total:
       spree/option_type:
         name: Nom
         presentation: Présentation
@@ -258,11 +262,18 @@ fr:
         ip_address: Adresse IP
         item_total: Nombre total d'articles
         number: Nombre
-        payment_state: "État du paiement"
-        shipment_state: "État du colis"
+        payment_state: État du paiement
+        shipment_state: État du colis
         special_instructions: Instructions spéciales
         state: État de la commande
         total: Total
+        additional_tax_total: TVA
+        approved_at: approuver le
+        approver_id: Approbateur
+        canceled_at: Annulé le
+        canceler_id: Annulateur
+        included_tax_total:
+        shipment_total: Envois Totales
       spree/order/bill_address:
         address1: Rue de l'adresse de facturation
         city: Ville de l'adresse de facturation
@@ -281,8 +292,16 @@ fr:
         zipcode: Code postal de l'adresse de livraison
       spree/payment:
         amount: Montant
+        number: Identification
+        response_code:
+        state: État du paiement
       spree/payment_method:
         name: Nom
+        active: Actif
+        auto_capture: Acceptation automatique
+        description: Description
+        display_on: Afficher
+        type: Fournisseur
       spree/product:
         available_on: Disponible le
         cost_currency: Devise du prix
@@ -293,6 +312,16 @@ fr:
         on_hand: En Stock
         shipping_category: Catégorie de livraison
         tax_category: Catégorie de taxe
+        depth: Profondeur
+        height: Taille
+        meta_description: Description Meta
+        meta_keywords: Mots clés Meta
+        meta_title: Titre du site
+        price: Prix de départ
+        promotionable:
+        slug: Identifiant
+        weight: Poids
+        width: Largeur
       spree/promotion:
         advertise: Publiciser
         code: Code
@@ -312,6 +341,7 @@ fr:
         name: Nom
       spree/return_authorization:
         amount: Montant
+        pre_tax_total:
       spree/role:
         name: Nom
       spree/state:
@@ -335,14 +365,22 @@ fr:
       spree/tax_category:
         description: Description
         name: Nom
+        is_default: Défaut
+        tax_code:
       spree/tax_rate:
         amount: Taux
         included_in_price: Inclus dans le prix
         show_rate_in_label: Afficher le taux dans l'étiquette
+        name: Nom
       spree/taxon:
         name: Nom
         permalink: Permalien
         position: Position
+        description: Description
+        icon: Icône
+        meta_description: Description Meta
+        meta_keywords: Mots clés Meta
+        meta_title: Titre du site
       spree/taxonomy:
         name: Nom
       spree/user:
@@ -361,25 +399,138 @@ fr:
       spree/zone:
         description: Description
         name: Nom
+        default_tax: Zone de taxe par défaut
+      spree/adjustment:
+        adjustable: Ajustable
+        amount: Montant
+        label: Description
+        name: Nom
+        state: État
+        adjustment_reason_id: Raison
+      spree/adjustment_reason:
+        active: Actif
+        code: Code
+        name: Nom
+        state: État
+      spree/carton:
+        tracking: Localiser
+      spree/customer_return:
+        number: N° de retour
+        pre_tax_total:
+        total: Total
+        reimbursement_status:
+        name: Nom
+      spree/image:
+        alt: Texte alternatif
+        attachment: Nom du fichier
+      spree/legacy_user:
+        email: Courriel
+        password: Mot de passe
+        password_confirmation: Confirmation du mot de passe
+      spree/option_value:
+        name: Nom
+        presentation: Présentation
+      spree/product_property:
+        value: Valeur
+      spree/refund:
+        amount: Montant
+        description: Description
+        refund_reason_id: Raison
+      spree/refund_reason:
+        active: Actif
+        name: Nom
+        code: Code
+      spree/reimbursement:
+        number: Nombre
+        reimbursement_status: Statut
+        total: Total
+      spree/reimbursement/credit:
+        amount: Montant
+      spree/reimbursement_type:
+        name: Nom
+        type: Type
+      spree/return_item:
+        acceptance_status: Statuts d'acceptation
+        acceptance_status_errors: Erreurs d'acceptation
+        charged: Chargé
+        exchange_variant: Échange pour
+        inventory_unit_state: État
+        override_reimbursement_type_id:
+        preferred_reimbursement_type_id:
+        reception_status: Statut de réception
+        return_reason: Raison
+        total: Total
+      spree/return_reason:
+        name: Nom
+        active: Actif
+        memo: note
+        number: Numéro RMA
+        state: État
+      spree/shipping_category:
+        name: Nom
+      spree/shipment:
+        tracking: Numéro de suivi
+      spree/shipping_method:
+        admin_name: Nom interne
+        code: Code
+        display_on: Afficher
+        name: Nom
+        tracking_url: URL du traqueur
+      spree/shipping_rate:
+        tax_rate: Taux de la taxe
+        amount: Montant
+      spree/store_credit:
+        amount: Montant
+        memo: note
+      spree/store_credit_event:
+        action: Action
+      spree/stock_item:
+        count_on_hand: Nombre en stock
+      spree/stock_location:
+        admin_name: Nom interne
+        active: Actif
+        address1: Adresse
+        address2: Adresse (suite)
+        backorderable_default: Peut être acheté même si le stock est vide (défault)
+        city: Ville
+        code: Code
+        country_id: Pays
+        default: Défaut
+        internal_name: Nom interne
+        name: Nom
+        phone: Téléphone
+        propagate_all_variants:
+        state_id: Province / Région / État
+        zipcode: Code postal
+      spree/stock_movement:
+        action: Action
+        quantity: Quantité
+      spree/stock_transfer:
+        created_at: Date de création
+        description: Description
+        tracking_number: Numéro de suivi
+      spree/tracker:
+        analytics_id: ID Google Analytics
+        active: Actif
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number: "Les clés Tier devraient toutes être des nombres plus grand que 0"
+              keys_should_be_positive_number: Les clés Tier devraient toutes être des nombres plus grand que 0
             preferred_tiers:
-              should_be_hash: "devrait être une table de hachage"
+              should_be_hash: devrait être une table de hachage
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number: "Les clés Tier devraient toutes être des nombres plus grand que 0"
-              values_should_be_percent: "Les valeurs Tier devraient toutes être des percentages compris entre 0% et 100%"
+              keys_should_be_positive_number: Les clés Tier devraient toutes être des nombres plus grand que 0
+              values_should_be_percent: Les valeurs Tier devraient toutes être des percentages compris entre 0% et 100%
             preferred_tiers:
-              should_be_hash: "devrait être une table de hachage"
+              should_be_hash: devrait être une table de hachage
         spree/classification:
           attributes:
             taxon_id:
-              already_linked: "est déjà relié à ce produit"
+              already_linked: est déjà relié à ce produit
         spree/credit_card:
           attributes:
             base:
@@ -522,6 +673,24 @@ fr:
       spree/zone:
         one: Zone
         other: Zones
+      spree/adjustment:
+        one: Ajustement
+        other: Ajustements
+      spree/calculator:
+        one: Calculateur
+      spree/legacy_user:
+        one: Utilisateur
+        other: Utilisateurs
+      spree/log_entry:
+        other: Entrées dans le journal
+      spree/product_property:
+        other: Propriété du produit
+      spree/refund:
+        one: Remboursement
+        other: Remboursements
+      spree/store_credit_category:
+        one: Categorie
+        other: Catégories
   devise:
     confirmations:
       confirmed: Votre compte a été confirmé avec succès. Vous êtes maintenant enregistré.
@@ -589,6 +758,11 @@ fr:
       refund: Rembourser
       save: Enregistrer
       update: Mise à jour
+      add: Ajouter
+      delete: Supprimer
+      remove: Supprimer
+      ship: livraison
+      split: Diviser
     activate: Activer
     active: Actif
     add: Ajouter
@@ -631,13 +805,20 @@ fr:
         taxonomies: Taxonomies
         taxons: Taxons
         users: Utilisateurs
+        checkout: Passer la commande
+        general: Général
+        payments: Paiements
+        promotion_categories: Catégories de promotion
+        settings: Paramètres
+        shipping: Frais de livraison
+        stock:
       user:
         account: Compte
         addresses: Adresses
         items: Articles
         items_purchased: Articles achetés
         order_history: Historique des commandes
-        order_num: "Commande #"
+        order_num: 'Commande #'
         orders: Commandes
         user_information: Informations de l'utilisateur
     administration: Administration
@@ -668,7 +849,7 @@ fr:
     approved_at: approuver le
     approver: Approbateur
     are_you_sure: En êtes-vous sûr ?
-    are_you_sure_delete: "Êtes-vous sûr de vouloir supprimer cet enregistrement ?"
+    are_you_sure_delete: Êtes-vous sûr de vouloir supprimer cet enregistrement ?
     associated_adjustment_closed: L'ajustement associé est fermé, et ne sera pas recalculé. Voulez-vous l'ouvrir?
     authorization_failure: Vous n'avez pas les droits nécessaires pour afficher cette section
     authorized: Autorisé
@@ -679,7 +860,7 @@ fr:
     back: Retour
     back_end: Gestion
     back_to_payment: Retour au paiement
-    back_to_resource_list: 'Retour à la liste %{resource}'
+    back_to_resource_list: Retour à la liste %{resource}
     back_to_rma_reason_list: Retour à la liste des RMA
     back_to_store: Boutique
     back_to_users_list: Retour à la liste des utilisateurs
@@ -713,15 +894,15 @@ fr:
     card_type_is: Le type de la carte est
     cart: Panier
     cart_subtotal:
-      one: 'Sous-total (1 article)'
-      other: 'Sous-total (%{count} articles)'
+      one: Sous-total (1 article)
+      other: Sous-total (%{count} articles)
     categories: Catégories
     category: Categorie
     charged: Chargé
     check_for_spree_alerts: Recevoir les alertes de Spree
     checkout: Passer la commande
     choose_a_customer: Choisissez un client
-    choose_a_taxon_to_sort_products_for: "Choisir une taxon pour organiser les produits pour"
+    choose_a_taxon_to_sort_products_for: Choisir une taxon pour organiser les produits pour
     choose_currency: Choisir la devise
     choose_dashboard_locale: Choisir la langue du tableau de bord
     choose_location: Choisir la localisation
@@ -729,7 +910,7 @@ fr:
     clear_cache: Supprimer la cache
     clear_cache_ok: La cache a bien été supprimée
     clear_cache_warning: Supprimer la cache va temporairement réduire les performances de votre boutique.
-    click_and_drag_on_the_products_to_sort_them:  Cliquer et faire glisser les produits pour les organiser.
+    click_and_drag_on_the_products_to_sort_them: Cliquer et faire glisser les produits pour les organiser.
     clone: Cloner
     close: Fermer
     close_all_adjustments: Fermer tous les ajustements
@@ -859,7 +1040,7 @@ fr:
     errors_prohibited_this_record_from_being_saved:
       one: 1 erreur empêche l'enregistrement de cette entrée
       other: "%{count} erreurs empêchent l'enregistrement de cette entrée"
-    event: "Événements"
+    event: Événements
     events:
       spree:
         cart:
@@ -937,8 +1118,8 @@ fr:
     incomplete: Incomplet
     info_number_of_skus_not_shown:
       one: un
-      other: "et %{count} autres"
-    info_product_has_multiple_skus: "Ce produit possède %{count} variantes:"
+      other: et %{count} autres
+    info_product_has_multiple_skus: 'Ce produit possède %{count} variantes:'
     instructions_to_reset_password: 'Remplissez le formulaire ci-dessous et les instructions pour réinitialiser votre mot de passe vous seront envoyées par courriel:'
     insufficient_stock: Stock disponible insuffisant, il n'en reste seulement que %{on_hand}
     insufficient_stock_lines_present: Nous n'avons pas tous les articles de votre commande dans notre inventaire.
@@ -1107,8 +1288,8 @@ fr:
         instructions: Votre commande a été ANNULÉE. Veuillez conserver les informations suivantes à propos de votre commande annulée.
         order_summary_canceled: Sommaire de la commande [ANNULÉE]
         subject: Annulation de la commande
-        subtotal: ! 'Sous-total: %{subtotal}'
-        total: ! 'Total de la commande: %{total}'
+        subtotal: 'Sous-total: %{subtotal}'
+        total: 'Total de la commande: %{total}'
       confirm_email:
         dear_customer: Cher client,
         instructions: Veuillez vérifier et sauvegarder les informations suivantes à propos de votre commande.
@@ -1116,7 +1297,9 @@ fr:
         subject: Confirmation de commande
         subtotal: Sous-total de la commande
         thanks: Merci d'avoir fait affaire avec nous.
-        total: ! 'Total de la commande: %{total}'
+        total: 'Total de la commande: %{total}'
+      inventory_cancellation:
+        dear_customer: Cher client,\n
     order_not_found: Impossible de trouver votre commande. Merci d'essayer à nouveau.
     order_number: Facture %{number}
     order_processed_successfully: Votre commande a été traitée avec succès
@@ -1134,7 +1317,7 @@ fr:
       resumed: reprise
       returned: retourné
     order_summary: Résumé de la commande
-    order_sure_want_to: "Êtes-vous certain de vouloir %{event} cette commande ?"
+    order_sure_want_to: Êtes-vous certain de vouloir %{event} cette commande ?
     order_total: Total de la commande
     order_updated: Commande mise à jour
     orders: Commandes
@@ -1143,7 +1326,7 @@ fr:
     overview: Vue d'ensemble
     package_from: Paquet de
     pagination:
-      next_page: "page suivante »"
+      next_page: page suivante »
       previous_page: "« page précédente"
       truncate: "…"
     password: Mot de passe
@@ -1160,13 +1343,13 @@ fr:
     payment_processing_failed: Le paiement ne peut être effectué, merci de vérifier les informations fournies
     payment_processor_choose_banner_text: Si vous avez besoin d'aide pour schoisir une méthode de paiement, svp visitez
     payment_processor_choose_link: notre page de paiements
-    payment_state: "État du paiement"
+    payment_state: État du paiement
     payment_states:
       balance_due: solde dû
       checkout: commandé
       completed: terminé
       credit_owed: crédit dû
-      failed: "échec"
+      failed: échec
       paid: payé
       pending: en attente
       processing: en cours
@@ -1185,7 +1368,6 @@ fr:
     pre_tax_amount:
     pre_tax_refund_amount:
     pre_tax_total:
-    preferred_reimbursement_type:
     preferred_reimbursement_type:
     presentation: Présentation
     previous: Précédent
@@ -1384,7 +1566,7 @@ fr:
         thanks: Merci pour votre activité.
         track_information: 'Suivi de l''Information: %{tracking}'
         track_link: 'Lien du traqueur: %{url}'
-    shipment_state: "État de livraison"
+    shipment_state: État de livraison
     shipment_states:
       backorder: Rupture de stock
       canceled: Annulé
@@ -1586,3 +1768,27 @@ fr:
     zipcode: Code postal
     zone: Zone
     zones: Zones
+    canceled: annulée
+    cannot_create_payment_link: S'il vous plaît définissez d'abord certains modes de paiement.
+    inventory_states:
+      canceled: annulée
+      returned: retourné
+      shipped: Expédié
+    no_resource_found_link: Ajouter une
+    number: Nombre
+    store_credit:
+      display_action:
+        adjustment: Ajustement
+        credit: Crédit
+        void: Crédit
+        admin:
+          authorize: Autorisé
+    store_credit_category:
+      default: Défaut
+  activemodel:
+    attributes:
+      spree/order_cancellations:
+        quantity: Quantité
+        state: État
+        shipment: Livraison
+        cancel: Annuler


### PR DESCRIPTION
Recent changes made to admin translations in solidus moved many of the keys. This was done to better use the ActiveModel translation conventions.

I wrote a [script](https://github.com/StemboltHQ/solidus_i18n_convert) that scans through the locale files in solidus_i18n looking for missing keys when compared to `en.yml` in core. Since these translations are just moved, the script attempts to make the same moves in this locale as were made for english.

Reviews would be appreciated to find any blatant mistranslations.
