### PR TITLE
Convert vi translations from solidus 1.2 -> 1.3

### DIFF
--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1,16 +1,18 @@
+---
 vi:
   activerecord:
     attributes:
       spree/address:
-        address1: "Địa chỉ"
-        address2: "Địa chỉ (tiếp)"
+        address1: Địa chỉ
+        address2: Địa chỉ (tiếp)
         city: Thành phố
         country: Quốc gia
         firstname: Tên
         lastname: Họ
-        phone: "Điện thoại"
+        phone: Điện thoại
         state: Bang
         zipcode: Mã Zip
+        company: Công ty
       spree/calculator/tiered_flat_rate:
         preferred_base_amount:
         preferred_tiers:
@@ -23,6 +25,7 @@ vi:
         iso_name: Tên ISO
         name: Tên
         numcode: Mã ISO
+        states_required: Yêu cầu bang
       spree/credit_card:
         base:
         cc_type: Kiểu
@@ -31,11 +34,16 @@ vi:
         number: Số
         verification_value: Thông số kiểm tra
         year: Năm
+        card_code: Mã thẻ
+        expiration: Mãn hạn
       spree/inventory_unit:
         state: Bang
       spree/line_item:
         price: Giá
         quantity: Số lượng
+        description: Miêu tả món hàng
+        name: Tên
+        total:
       spree/option_type:
         name: Tên
         presentation: Thể hiện
@@ -46,7 +54,7 @@ vi:
         coupon_code:
         created_at: Ngày đặt hàng
         email: Email của khách hàng
-        ip_address: "Địa chỉ IP"
+        ip_address: Địa chỉ IP
         item_total: Tổng sản phẩm
         number: Số
         payment_state: Trạng thái thanh toán
@@ -54,26 +62,41 @@ vi:
         special_instructions: Chỉ dẫn đặc biệt
         state: Bang
         total: Tổng
+        additional_tax_total: Thuế
+        approved_at:
+        approver_id:
+        canceled_at:
+        canceler_id:
+        included_tax_total:
+        shipment_total: Tổng chuyển hàng
       spree/order/bill_address:
-        address1: "Đỉa chị thanh toán - tên đường"
-        city: "Đỉa chị thanh toán - thành phố"
-        firstname: "Đỉa chị thanh toán - tên"
-        lastname: "Đỉa chị thanh toán - họ"
-        phone: "Đỉa chị thanh toán - ĐT"
-        state: "Đỉa chị thanh toán - bang"
-        zipcode: "Đỉa chị thanh toán - mã zip"
+        address1: Đỉa chị thanh toán - tên đường
+        city: Đỉa chị thanh toán - thành phố
+        firstname: Đỉa chị thanh toán - tên
+        lastname: Đỉa chị thanh toán - họ
+        phone: Đỉa chị thanh toán - ĐT
+        state: Đỉa chị thanh toán - bang
+        zipcode: Đỉa chị thanh toán - mã zip
       spree/order/ship_address:
-        address1: "Đỉa chị giao hàng - tên đường"
-        city: "Đỉa chị giao hàng - thành phố"
-        firstname: "Đỉa chị giao hàng - tên"
-        lastname: "Đỉa chị giao hàng - họ"
-        phone: "Đỉa chị giao hàng - ĐT"
-        state: "Đỉa chị giao hàng - bang"
-        zipcode: "Đỉa chị giao hàng - mã zip"
+        address1: Đỉa chị giao hàng - tên đường
+        city: Đỉa chị giao hàng - thành phố
+        firstname: Đỉa chị giao hàng - tên
+        lastname: Đỉa chị giao hàng - họ
+        phone: Đỉa chị giao hàng - ĐT
+        state: Đỉa chị giao hàng - bang
+        zipcode: Đỉa chị giao hàng - mã zip
       spree/payment:
         amount: Giá trị
+        number:
+        response_code:
+        state:
       spree/payment_method:
         name:
+        active: Có hiệu lực
+        auto_capture:
+        description: Miêu tả
+        display_on:
+        type: Nhà cung cấp
       spree/product:
         available_on: Available On
         cost_currency: Tiền giá
@@ -84,6 +107,16 @@ vi:
         on_hand:
         shipping_category:
         tax_category: Mục thuế
+        depth: Sâu
+        height: Cao
+        meta_description: Meta miểu tả
+        meta_keywords: Meta danh sách từ khóa
+        meta_title:
+        price: Giá chủ
+        promotionable:
+        slug:
+        weight: Khối lượng
+        width: Rộng
       spree/promotion:
         advertise: Quảng cáo
         code: Mã
@@ -91,7 +124,7 @@ vi:
         event_name: Tên sự kiện
         expires_at: Hết hạn lúc
         name: Tên
-        path: "Đường dẫn"
+        path: Đường dẫn
         starts_at: Bắt đầu lúc
         usage_limit: Giới hạn sử dụng
       spree/promotion_category:
@@ -103,6 +136,7 @@ vi:
         name: Tên
       spree/return_authorization:
         amount: Giá trị
+        pre_tax_total:
       spree/role:
         name: Tên
       spree/state:
@@ -126,14 +160,22 @@ vi:
       spree/tax_category:
         description: Chú thích
         name: Tên
+        is_default:
+        tax_code:
       spree/tax_rate:
         amount: Mức giá
         included_in_price:
         show_rate_in_label:
+        name: Tên
       spree/taxon:
         name:
         permalink:
         position:
+        description: Miêu tả
+        icon: Biểu tượng
+        meta_description: Meta miểu tả
+        meta_keywords: Meta danh sách từ khóa
+        meta_title:
       spree/taxonomy:
         name:
       spree/user:
@@ -152,6 +194,118 @@ vi:
       spree/zone:
         description:
         name:
+        default_tax:
+      spree/adjustment:
+        adjustable:
+        amount: Giá trị
+        label: Miêu tả
+        name: Tên
+        state: Bang
+        adjustment_reason_id: Lí do
+      spree/adjustment_reason:
+        active: Có hiệu lực
+        code: Mã
+        name: Tên
+        state: Bang
+      spree/carton:
+        tracking: Theo dõi
+      spree/customer_return:
+        number:
+        pre_tax_total:
+        total: Giá trị
+        reimbursement_status:
+        name: Tên
+      spree/image:
+        alt: Chú thích khác
+        attachment: Tên tệp tin
+      spree/legacy_user:
+        email:
+        password: Mật khẩu
+        password_confirmation: Xác nhận mật khẩu
+      spree/option_value:
+        name: Tên
+        presentation: Trình bày
+      spree/product_property:
+        value: Giá trị
+      spree/refund:
+        amount: Giá trị
+        description: Miêu tả
+        refund_reason_id: Lí do
+      spree/refund_reason:
+        active: Có hiệu lực
+        name: Tên
+        code: Mã
+      spree/reimbursement:
+        number: Số
+        reimbursement_status: Tình trạng
+        total: Giá trị
+      spree/reimbursement/credit:
+        amount: Giá trị
+      spree/reimbursement_type:
+        name: Tên
+        type: Loại
+      spree/return_item:
+        acceptance_status:
+        acceptance_status_errors:
+        charged:
+        exchange_variant:
+        inventory_unit_state: Bang
+        override_reimbursement_type_id:
+        preferred_reimbursement_type_id:
+        reception_status:
+        return_reason: Lí do
+        total: Giá trị
+      spree/return_reason:
+        name: Tên
+        active: Có hiệu lực
+        memo:
+        number: Số RMA
+        state: Bang
+      spree/shipping_category:
+        name: Tên
+      spree/shipment:
+        tracking: Số theo dõi
+      spree/shipping_method:
+        admin_name:
+        code: Mã
+        display_on:
+        name: Tên
+        tracking_url: URL theo dõi
+      spree/shipping_rate:
+        amount: Giá trị
+      spree/store_credit:
+        amount: Giá trị
+        memo:
+      spree/store_credit_event:
+        action: Lệnh
+      spree/stock_item:
+        count_on_hand: Số hàng có trong tay
+      spree/stock_location:
+        admin_name:
+        active: Có hiệu lực
+        address1: Địa chỉ
+        address2: Địa chỉ (tiếp)
+        backorderable_default:
+        city: Thành phố
+        code: Mã
+        country_id: Quốc gia
+        default:
+        internal_name:
+        name: Tên
+        phone: Điện thoại
+        propagate_all_variants:
+        state_id: Bang
+        zipcode: Mã bưu điện
+      spree/stock_movement:
+        action: Lệnh
+        quantity: Số lượng
+      spree/stock_transfer:
+        created_at: Tạo lúc
+        description: Miêu tả
+        tracking_number: Số theo dõi
+      spree/tracker:
+        analytics_id: Analytics ID
+        active: Có hiệu lực
     errors:
       models:
         spree/calculator/tiered_flat_rate:
@@ -199,51 +353,131 @@ vi:
             base:
               cannot_destroy_default_store:
     models:
-      spree/address: "Địa chỉ"
-      spree/country: Quốc gia
-      spree/credit_card: Thẻ tín dụng
+      spree/address:
+        one: Địa chỉ
+        other:
+      spree/country:
+        one: Quốc gia
+        other: Quốc gia
+      spree/credit_card:
+        one: Thẻ tín dụng
+        other:
       spree/customer_return:
-      spree/inventory_unit: "Đơn vị hàng"
+        one:
+        other:
+      spree/inventory_unit: Đơn vị hàng
       spree/line_item:
       spree/option_type:
+        one: Option Type
+        other: Kiểu tùy chọn
       spree/option_value:
-      spree/order: "Đơn đặt hàng"
-      spree/payment: Thanh toán
+        one: Option Value
+        other: Giá trị tùy chọn
+      spree/order:
+        one: Đơn hàng
+        other: Đơn hàng
+      spree/payment:
+        one: Thanh toán
+        other: Thanh toán
       spree/payment_method:
-      spree/product: Sản phẩm
+        one: Phương thức thanh toán
+        other: Phương thức thanh toán
+      spree/product:
+        one: Sản phẩm
+        other: Sản phẩm
       spree/promotion:
+        one:
+        other:
       spree/promotion_category:
-      spree/property: Thuộc tính
-      spree/prototype: Mẫu hàng
+        other:
+      spree/property:
+        one: Đặc tính
+        other: Đặc tính
+      spree/prototype:
+        one: Nguyên mẫu
+        other: Nguyên mẫu
       spree/refund_reason:
+        other:
       spree/reimbursement:
+        one:
+        other:
       spree/reimbursement_type:
+        other:
       spree/return_authorization:
+        one: Ủy Quyền Trả Về
+        other: Ủy Quyền Trả Về
       spree/return_authorization_reason:
       spree/role:
+        one: Vai trò
+        other: Vai trò
       spree/shipment:
+        one: Vận chuyển
+        other: Vận chuyển
       spree/shipping_category:
+        one: Loại vận chuyển
+        other: Loại vận chuyển
       spree/shipping_method:
+        one: Phương thức vận chuyển
+        other: Phương thức vận chuyển
       spree/state:
+        one: Bang
+        other: Bang
       spree/state_change:
       spree/stock_location:
+        one: Địa điểm hàng
+        other: Địa điểm hàng
       spree/stock_movement:
+        other: Chuyển động của hàng
       spree/stock_transfer:
+        one: Chuyển hàng
+        other: Chuyển hàng
       spree/tax_category:
+        one: Biểu thuế
+        other: Loại thuế
       spree/tax_rate:
+        other: Lãi suất thuế
       spree/taxon:
+        one: Đơn vị phân loại
+        other: Đơn vị phân loại
       spree/taxonomy:
+        one: Taxonomy
+        other: Phân loại
       spree/tracker:
+        other: Theo dõi thông số thống kê
       spree/user:
+        one: Người dùng
+        other: Người dùng
       spree/variant:
+        one: Variant
+        other: Biến thể
       spree/zone:
+        one: Vùng
+        other: Vùng
+      spree/adjustment:
+        one: Điều chỉnh
+        other: Điều chỉnh
+      spree/calculator:
+        one: Máy tính
+      spree/legacy_user:
+        one: Người dùng
+        other: Người dùng
+      spree/log_entry:
+        other:
+      spree/product_property:
+        other: Đặc tính sản phẩm
+      spree/refund:
+        one: Thối
+        other:
+      spree/store_credit_category:
+        one: Loại mặt hàng
+        other: Loại mặt hàng
   devise:
     confirmations:
       confirmed: Tài khoản của bạn đã được xác nhận thành công. Bạn đang đăng nhập vào.
       send_instructions: Bạn sẽ nhận được thư hướng dẫn xác nhận tài khoản của mình trong một vài phút tới.
     failure:
       inactive: Tài khoản của bạn chưa được kích hoạt.
-      invalid: "Địa chỉ hòm thư hoặc mật khẩu không hợp lệ."
+      invalid: Địa chỉ hòm thư hoặc mật khẩu không hợp lệ.
       invalid_token: Token ủy quyền không đúng.
       locked: Tài khoản của bạn đang bị khoá.
       timeout: Session hết hạn, xin vui lòng đăng nhập lại.
@@ -273,11 +507,11 @@ vi:
       signed_up: Chào mừng! Bạn đã thành công đăng kí.
       updated: Bạn đã thành công cập nhật tài khoản.
     user_sessions:
-      signed_in: "Đăng nhập thành công."
-      signed_out: "Đăng xuất thành công."
+      signed_in: Đăng nhập thành công.
+      signed_out: Đăng xuất thành công.
   errors:
     messages:
-      already_confirmed: "đã được chứng nhận"
+      already_confirmed: đã được chứng nhận
       not_found: không tìm thấy
       not_locked: không bị khoá
       not_saved: "%{count} lỗi cấm %{resource} này lưu:"
@@ -302,6 +536,11 @@ vi:
       refund:
       save: Lưu
       update: Cập nhật
+      add: Thêm
+      delete: Xóa
+      remove: Xóa
+      ship: Gửi
+      split:
     activate: Kích hoạt
     active: Có hiệu lực
     add: Thêm
@@ -321,15 +560,15 @@ vi:
     add_to_cart: Cho vào sọt
     add_variant: Tạo biến thể
     additional_item: Giá phải trả thêm
-    address1: "Địa chỉ"
-    address2: "Địa chỉ (tiếp)"
+    address1: Địa chỉ
+    address2: Địa chỉ (tiếp)
     adjustable:
-    adjustment: "Điều chỉnh"
+    adjustment: Điều chỉnh
     adjustment_amount: Giá trị
-    adjustment_successfully_closed: "Điều chỉnh đã được đóng!"
-    adjustment_successfully_opened: "Điều chỉnh đã được mở!"
+    adjustment_successfully_closed: Điều chỉnh đã được đóng!
+    adjustment_successfully_opened: Điều chỉnh đã được mở!
     adjustment_total: Tổng Điều chỉnh
-    adjustments: "Điều chỉnh"
+    adjustments: Điều chỉnh
     admin:
       tab:
         configuration:
@@ -345,6 +584,12 @@ vi:
         taxonomies:
         taxons:
         users:
+        checkout: Thủ tục mua hàng
+        general: Tổng quan
+        payments: Thanh toán
+        settings: Cấu hình
+        shipping: Vận chuyển
+        stock:
       user:
         account:
         addresses:
@@ -356,8 +601,8 @@ vi:
         user_information:
     administration: Quản trị
     advertise:
-    agree_to_privacy_policy: "Đồng ý với Điều khoản riêng tư"
-    agree_to_terms_of_service: "Đồng ý với Điều khoản dịch vụ"
+    agree_to_privacy_policy: Đồng ý với Điều khoản riêng tư
+    agree_to_terms_of_service: Đồng ý với Điều khoản dịch vụ
     all: Tất cả
     all_adjustments_closed: Tất cả điều chỉnh đã được đóng!
     all_adjustments_opened: Tất cả điều chỉnh đã được mở!
@@ -368,7 +613,7 @@ vi:
     allow_ssl_in_staging: Cho phép dùng SSL trong môi trường staging
     already_signed_up_for_analytics: Bạn đã đăng kí với Spree Analytics rồi
     alt_text: Chú thích khác
-    alternative_phone: "Điện thoại khác"
+    alternative_phone: Điện thoại khác
     amount: Giá trị
     analytics_desc_header_1: Thống kê Spree
     analytics_desc_header_2: Các thông số thống kê được tích hợp vào Spree dashboard
@@ -383,8 +628,8 @@ vi:
     approver:
     are_you_sure: Bạn có chắn chắn không?
     are_you_sure_delete: Bạn có chắc bạn muốn xóa hồ sơ này không?
-    associated_adjustment_closed: "Điều chỉnh liên đới đã bị đóng và không thể tính lại. Bạn có muốn mở nó không?"
-    at_symbol: '@'
+    associated_adjustment_closed: Điều chỉnh liên đới đã bị đóng và không thể tính lại. Bạn có muốn mở nó không?
+    at_symbol: "@"
     authorization_failure: Không được ủy quyền truy cập
     authorized:
     auto_capture:
@@ -405,9 +650,9 @@ vi:
     balance_due: Tiền cần thanh toán
     base_amount:
     base_percent:
-    bill_address: "Địa chỉ thanh toán"
+    bill_address: Địa chỉ thanh toán
     billing: Thanh Toán
-    billing_address: "Địa chỉ thanh toán"
+    billing_address: Địa chỉ thanh toán
     both: Both
     calculated_reimbursements:
     calculator: Máy tính
@@ -444,8 +689,8 @@ vi:
     clear_cache_warning:
     click_and_drag_on_the_products_to_sort_them:
     clone: Nhân bản
-    close: "Đóng"
-    close_all_adjustments: "Đóng tất cả chỉnh sửa"
+    close: Đóng
+    close_all_adjustments: Đóng tất cả chỉnh sửa
     code: Mã
     company: Công ty
     complete: hoàn tất
@@ -492,12 +737,12 @@ vi:
     credit_owed: Nợ tín dụng
     credits:
     currency:
-    currency_decimal_mark: "Điểm phân cách tiền hàng số lẻ"
+    currency_decimal_mark: Điểm phân cách tiền hàng số lẻ
     currency_settings:
     currency_symbol_position:
     currency_thousands_separator: Phân cách số hàng nghìn
     current: Hiện thời
-    current_promotion_usage: "Đang dùng: %{count}"
+    current_promotion_usage: 'Đang dùng: %{count}'
     customer: Khách hàng
     customer_details: Thông tin khách hàng
     customer_details_updated: The customer's details have been updated.
@@ -532,7 +777,7 @@ vi:
     delivery: Delivery
     depth: Sâu
     description: Miêu tả
-    destination: "Đích đến"
+    destination: Đích đến
     destroy: Hủy diệt
     details:
     discount_amount:
@@ -607,7 +852,7 @@ vi:
     first_item: Món hàng đầu tiên giá
     first_name: Tên
     first_name_begins_with: Tên bắt đầu với
-    flat_percent: "Định mức phần trăm"
+    flat_percent: Định mức phần trăm
     flat_rate_per_order: Lãi suất sàn (cho từng đơn hàng)
     flexible_rate: Lãi suất dao động
     forgot_password: Quên mật khẩu
@@ -645,7 +890,7 @@ vi:
     incomplete:
     info_number_of_skus_not_shown:
     info_product_has_multiple_skus:
-    instructions_to_reset_password: "Điền vào mẫu phía dưới và hướng dẫn cách thay đổi mật khẩu sẽ được gửi qua email đến bạn:"
+    instructions_to_reset_password: 'Điền vào mẫu phía dưới và hướng dẫn cách thay đổi mật khẩu sẽ được gửi qua email đến bạn:'
     insufficient_stock: Không đủ hàng, chỉ còn lại %{on_hand}
     insufficient_stock_lines_present:
     intercept_email_address: Can thiệp địa chỉ email
@@ -657,7 +902,7 @@ vi:
     invalid_promotion_action: Hành động khuyến mại không đúng.
     invalid_promotion_rule: Luật khuyến mại không đúng.
     inventory: Hàng
-    inventory_adjustment: "Điều chỉnh hàng tồn"
+    inventory_adjustment: Điều chỉnh hàng tồn
     inventory_error_flash_for_insufficient_quantity: Một sản phẩm trong sọt của bạn đã cháy hàng.
     inventory_state:
     is_not_available_to_shipment_address: không thể chuyển đến địa chỉ chỉ định
@@ -677,26 +922,26 @@ vi:
     items_to_be_reimbursed:
     jirafe: Jirafe
     landing_page_rule:
-      path: "Đường dẫn"
+      path: Đường dẫn
     last_name: Họ
     last_name_begins_with: Tên họ bắt đầu với
-    learn_more: "Đọc thêm"
+    learn_more: Đọc thêm
     lifetime_stats:
     line_item_adjustments:
     list: Liệt kê
-    loading: "Đang tải"
+    loading: Đang tải
     locale_changed: Thay đổi địa hóa
-    location: "Địa điểm"
+    location: Địa điểm
     lock: Khoá
     log_entries:
-    logged_in_as: "Đã đăng nhập với"
-    logged_in_succesfully: "Đăng nhập thành công"
+    logged_in_as: Đã đăng nhập với
+    logged_in_succesfully: Đăng nhập thành công
     logged_out: Bạn đã đăng xuất
-    login: "Đăng nhập"
-    login_as_existing: "Đăng nhập như khách hàng cũ"
-    login_failed: "Đăng nhập không uy quyền."
-    login_name: "Đăng nhập"
-    logout: "Đăng xuất"
+    login: Đăng nhập
+    login_as_existing: Đăng nhập như khách hàng cũ
+    login_failed: Đăng nhập không uy quyền.
+    login_name: Đăng nhập
+    logout: Đăng xuất
     logs:
     look_for_similar_items: Tìm sản phẩm tương tự
     make_refund: Thối tiền
@@ -720,7 +965,7 @@ vi:
     more: Hơn nữa
     move_stock_between_locations: Dời hàng giữa kho
     my_account: Tài khoản của tôi
-    my_orders: "Đơn đặt hàng của tôi"
+    my_orders: Đơn đặt hàng của tôi
     name: Tên
     name_on_card:
     name_or_sku: Tên hoặc SKU
@@ -731,18 +976,18 @@ vi:
     new_customer_return:
     new_image: Hình mới
     new_option_type: Kiểu tùy chọn mới
-    new_order: "Đơn đặt hàng mới"
+    new_order: Đơn đặt hàng mới
     new_order_completed: Thanh toán mới hoàn tất
     new_payment: Thanh toán mới
     new_payment_method: Phương thức thanh toán mới
     new_product: Sản phẩm mới
     new_promotion: Khuyến mại mới
     new_promotion_category:
-    new_property: "Đặc tính mới"
+    new_property: Đặc tính mới
     new_prototype: Nguyên mẫu mới
     new_refund:
     new_refund_reason:
-    new_return_authorization: "Ủy quyền trả về mới"
+    new_return_authorization: Ủy quyền trả về mới
     new_rma_reason:
     new_shipment_at_location:
     new_shipping_category: Loại hình vận chuyển mới
@@ -753,7 +998,7 @@ vi:
     new_stock_transfer: Di chuyển hàng mới
     new_tax_category: Biểu thuế mới
     new_tax_rate: Lãi suất mới
-    new_taxon: "Đơn vị Phân loại mới"
+    new_taxon: Đơn vị Phân loại mới
     new_taxonomy: Phân loại mới
     new_tracker: Tracker mới
     new_user: Người dùng mới
@@ -780,8 +1025,8 @@ vi:
     not_found:
     note:
     notice_messages:
-      product_cloned: "Đã nhân bản sản phẩm"
-      product_deleted: "Đã xóa sản phẩm"
+      product_cloned: Đã nhân bản sản phẩm
+      product_deleted: Đã xóa sản phẩm
       product_not_cloned: Không thể nhân bản sản phẩm
       product_not_deleted: Không thể xóa sản phẩm
       variant_deleted: Biến thể đã được xóa
@@ -799,18 +1044,18 @@ vi:
     options: Tùy chọn
     or: hoặc
     or_over_price: "%{price} or over"
-    order: "Đơn hàng"
+    order: Đơn hàng
     order_adjustments:
     order_already_updated:
     order_approved:
     order_canceled:
     order_details: Chi tiết đơn hàng
-    order_email_resent: "Đơn hàng đã được gửi email lại"
+    order_email_resent: Đơn hàng đã được gửi email lại
     order_information: Thông tin đơn hàng
     order_mailer:
       cancel_email:
         dear_customer: Kính chào quý khách,\n
-        instructions: "Đơn đặt hàng của quý khách bị hủy. Vui lòng kiểm tra lại đơn hàng của bạn."
+        instructions: Đơn đặt hàng của quý khách bị hủy. Vui lòng kiểm tra lại đơn hàng của bạn.
         order_summary_canceled:
         subject:
         subtotal:
@@ -823,9 +1068,11 @@ vi:
         subtotal:
         thanks:
         total:
+      inventory_cancellation:
+        dear_customer: Kính chào quý khách,\n
     order_not_found: Không tìm thấy đơn hàng. Xin vui lòng thử hành động khác.
     order_number:
-    order_processed_successfully: "Đơn đặt hàng của bạn đã được xử lý thành công"
+    order_processed_successfully: Đơn đặt hàng của bạn đã được xử lý thành công
     order_resumed:
     order_state:
       address:
@@ -842,8 +1089,8 @@ vi:
     order_summary: Tóm tắt đơn đặt hàng
     order_sure_want_to: Bạn có chắc bạn muốn %{event} đơn hàng này?
     order_total: Tổng giá sau thuế
-    order_updated: "Đơn hàng được cập nhật"
-    orders: "Đơn hàng"
+    order_updated: Đơn hàng được cập nhật
+    orders: Đơn hàng
     other_items_in_other:
     out_of_stock: Hết hàng
     overview: Tổng kết
@@ -854,7 +1101,7 @@ vi:
       truncate: "…"
     password: Mật khẩu
     paste: Paste
-    path: "Đường dẫn"
+    path: Đường dẫn
     pay: thanh toán
     payment: Thanh toán
     payment_could_not_be_created:
@@ -883,8 +1130,8 @@ vi:
     percent: Phần trăm
     percent_per_item:
     permalink:
-    phone: "Điện thoại"
-    place_order: "Đặt hàng"
+    phone: Điện thoại
+    place_order: Đặt hàng
     please_define_payment_methods:
     populate_get_error:
     powered_by: Tiếp sức bởi
@@ -903,7 +1150,7 @@ vi:
     product_details: Chi tiết sản phẩm
     product_has_no_description: Sản phẩm không có chú thích
     product_not_available_in_this_currency: Sản phẩm này không được cung cấp ở tiền tệ được chọn.
-    product_properties: "Đặc tính sản phẩm"
+    product_properties: Đặc tính sản phẩm
     product_rule:
       choose_products:
       label:
@@ -967,8 +1214,8 @@ vi:
     promotionable:
     promotions:
     propagate_all_variants:
-    properties: "Đặc tính"
-    property: "Đặc tính"
+    properties: Đặc tính
+    property: Đặc tính
     prototype: Nguyên mẫu
     prototypes: Nguyên mẫu
     provider: Nhà cung cấp
@@ -982,7 +1229,7 @@ vi:
     reason: Lí do
     receive: nhận
     receive_stock: Nhận hàng
-    received: "Đã nhận"
+    received: Đã nhận
     reception_status:
     reference: Tham khảo
     refund: Thối
@@ -990,8 +1237,8 @@ vi:
     refund_reasons:
     refunded_amount:
     refunds:
-    register: "Đăng ký như một thành viên mới"
-    registration: "Đăng ký"
+    register: Đăng ký như một thành viên mới
+    registration: Đăng ký
     reimburse:
     reimbursed:
     reimbursement:
@@ -1022,12 +1269,12 @@ vi:
     reset_password: Khởi tạo lại mật khẩu
     response_code: Mã phản hồi
     resume: tiếp tục
-    resumed: "Đã tiếp tục"
+    resumed: Đã tiếp tục
     return: trở về
-    return_authorization: "Ủy Quyền Trả Về"
+    return_authorization: Ủy Quyền Trả Về
     return_authorization_reasons:
-    return_authorization_updated: "Ủy Quyền Trả Về đã được cập nhật"
-    return_authorizations: "Ủy Quyền Trả Về"
+    return_authorization_updated: Ủy Quyền Trả Về đã được cập nhật
+    return_authorizations: Ủy Quyền Trả Về
     return_item_inventory_unit_ineligible:
     return_item_inventory_unit_reimbursed:
     return_item_rma_ineligible:
@@ -1036,7 +1283,7 @@ vi:
     return_items_cannot_be_associated_with_multiple_orders:
     return_number:
     return_quantity: Số lượng trả về
-    returned: "Đã trả về"
+    returned: Đã trả về
     returns:
     review:
     risk:
@@ -1072,7 +1319,7 @@ vi:
     server_error: Máy chủ bị lỗi
     settings: Cấu hình
     ship: Gửi
-    ship_address: "Địa chỉ giao hàng"
+    ship_address: Địa chỉ giao hàng
     ship_total: Tổng chuyển hàng
     shipment: Vận chuyển
     shipment_adjustments:
@@ -1097,9 +1344,9 @@ vi:
     shipment_transfer_error:
     shipment_transfer_success:
     shipments: Vận chuyển
-    shipped: "Đã chuyển phát"
+    shipped: Đã chuyển phát
     shipping: Vận chuyển
-    shipping_address: "Địa chỉ giao hàng"
+    shipping_address: Địa chỉ giao hàng
     shipping_categories: Loại vận chuyển
     shipping_category: Loại vận chuyển
     shipping_flat_rate_per_item: Giá thấp nhất với từng mục gói
@@ -1166,9 +1413,9 @@ vi:
     states_required: Yêu cầu bang
     status: Tình trạng
     stock:
-    stock_location: "Địa điểm hàng"
+    stock_location: Địa điểm hàng
     stock_location_info: Thông tin địa điểm hàng
-    stock_locations: "Địa điểm hàng"
+    stock_locations: Địa điểm hàng
     stock_locations_need_a_default_country:
     stock_management: Quản lý hàng
     stock_management_requires_a_stock_location:
@@ -1179,8 +1426,8 @@ vi:
     stock_transfers: Chuyển hàng
     stop: Kết thúc
     store: Cửa hàng
-    street_address: "Địa chỉ"
-    street_address_2: "Địa chỉ (tiếp)"
+    street_address: Địa chỉ
+    street_address_2: Địa chỉ (tiếp)
     subtotal: Tổng giá trước thuế
     subtract: Trừ đi
     success:
@@ -1197,7 +1444,7 @@ vi:
     tax_included:
     tax_rate_amount_explanation: Mức thuế ở số thập phân để trợ giúp cách tính, (nghĩa là; nếu mức thuế là 5% thì nhập vào 0.05
     tax_rates: Lãi suất thuế
-    taxon: "Đơn vị phân loại"
+    taxon: Đơn vị phân loại
     taxon_edit: Sửa đổi đơn vị phân loại
     taxon_placeholder: Thêm vào một phân loại
     taxon_rule:
@@ -1210,7 +1457,7 @@ vi:
     taxonomy_edit: Sửa đổi phân loại
     taxonomy_tree_error: Thay đồi theo yêu cầu không được chấp nhận và hệ cây đã quay trở về trạng thái như trước, xin hay thử lại lần nữa.
     taxonomy_tree_instruction: "* Nhấp chuột phải vào 1 phần tử con trong hệ cây để truy cập thực đơn để thêm, xóa và sắp xếp một phần tử con."
-    taxons: "Đơn vị phân loại"
+    taxons: Đơn vị phân loại
     test: Kiểm tra
     test_mailer:
       test_email:
@@ -1227,7 +1474,7 @@ vi:
     tiered_percent:
     tiers:
     time: Thời gian
-    to_add_variants_you_must_first_define: "Để thêm biến thể, bạn phải định nghĩa trước"
+    to_add_variants_you_must_first_define: Để thêm biến thể, bạn phải định nghĩa trước
     total: Giá trị
     total_per_item:
     total_pre_tax_refund:
@@ -1252,7 +1499,7 @@ vi:
     unrecognized_card_type: Không nhận ra được loại thẻ
     unshippable_items: Sản phẩm không vận chuyển được
     update: Cập nhật
-    updating: "Đang cập nhật"
+    updating: Đang cập nhật
     usage_limit: Giới hạn sử dụng
     use_app_default:
     use_billing_address: Dùng địa chỉ thanh toán
@@ -1283,8 +1530,32 @@ vi:
     year: Năm
     you_have_no_orders_yet: You have no orders yet.
     your_cart_is_empty: Sọt hàng rỗng
-    your_order_is_empty_add_product: "Đơn hàng của bạn rỗng, xin hay tìm và thêm vào sản phảm như trên"
+    your_order_is_empty_add_product: Đơn hàng của bạn rỗng, xin hay tìm và thêm vào sản phảm như trên
     zip: Mã bưu điện
     zipcode: Mã Zip
     zone: Vùng
     zones: Vùng
+    canceled:
+    cannot_create_payment_link:
+    inventory_states:
+      canceled:
+      returned:
+      shipped:
+    no_resource_found_link: Tạo một
+    number: Số
+    store_credit:
+      display_action:
+        adjustment: Điều chỉnh
+        credit: Tín dụng
+        void: Tín dụng
+        admin:
+          authorize:
+    store_credit_category:
+      default:
+  activemodel:
+    attributes:
+      spree/order_cancellations:
+        quantity: Số lượng
+        state: Bang
+        shipment: Vận chuyển
+        cancel: Hủy


### PR DESCRIPTION
Recent changes made to admin translations in solidus moved many of the keys. This was done to better use the ActiveModel translation conventions.

I wrote a [script](https://github.com/StemboltHQ/solidus_i18n_convert) that scans through the locale files in solidus_i18n looking for missing keys when compared to `en.yml` in core. Since these translations are just moved, the script attempts to make the same moves in this locale as were made for english.

Reviews would be appreciated to find any blatant mistranslations.
