### PR TITLE
Convert th translations from solidus 1.2 -> 1.3

### DIFF
--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -1,16 +1,18 @@
+---
 th:
   activerecord:
     attributes:
       spree/address:
-        address1: "ที่อยู่"
-        address2: "ที่อยู่ 2"
-        city: "ตำบล"
-        country: "ประเทศ"
-        firstname: "ชื่อ"
-        lastname: "นามสกุล"
-        phone: "เบอร์โทรศัพท์"
-        state: "จังหวัด"
-        zipcode: "รหัสไปรษณีย์"
+        address1: ที่อยู่
+        address2: ที่อยู่ 2
+        city: ตำบล
+        country: ประเทศ
+        firstname: ชื่อ
+        lastname: นามสกุล
+        phone: เบอร์โทรศัพท์
+        state: จังหวัด
+        zipcode: รหัสไปรษณีย์
+        company: บริษัท
       spree/calculator/tiered_flat_rate:
         preferred_base_amount:
         preferred_tiers:
@@ -21,93 +23,125 @@ th:
         iso: ISO
         iso3: ISO3
         iso_name: ISO Name
-        name: "ชื่อประเทศ"
+        name: ชื่อประเทศ
         numcode: ISO Code
+        states_required: จังหวัดที่ต้องการ
       spree/credit_card:
         base:
-        cc_type: "ประเภท"
-        month: "เดือน"
+        cc_type: ประเภท
+        month: เดือน
         name:
-        number: "เลขที่บัตร"
-        verification_value: "เลขยืนยัน"
-        year: "ปี"
+        number: เลขที่บัตร
+        verification_value: เลขยืนยัน
+        year: ปี
+        card_code: รหัสบัตร
+        expiration: หมดอายุ
       spree/inventory_unit:
-        state: "จังหวัด"
+        state: จังหวัด
       spree/line_item:
-        price: "ราคา"
-        quantity: "จำนวน"
+        price: ราคา
+        quantity: จำนวน
+        description: รายละเอียดสินค้า
+        name: ชื่อ
+        total:
       spree/option_type:
-        name: "ชื่อเรียก"
-        presentation: "การแสดงผล"
+        name: ชื่อเรียก
+        presentation: การแสดงผล
       spree/order:
-        checkout_complete: "เช็คเอ้าท์เรียบร้อย"
-        completed_at: "รายการสมบูรณ์เมื่อ"
+        checkout_complete: เช็คเอ้าท์เรียบร้อย
+        completed_at: รายการสมบูรณ์เมื่อ
         considered_risky:
-        coupon_code: "เลขคูปอง"
-        created_at: "วันที่สั่งสินค้า"
-        email: "อีเมลของลูกค้า"
-        ip_address: "หลายเลขไอพี"
-        item_total: "รวม"
-        number: "หมายเลข"
-        payment_state: "จังหวัด"
-        shipment_state: "จังหวัด"
-        special_instructions: "ข้อแนะนำเพิ่มเติม"
-        state: "จังหวัด"
-        total: "รวม"
+        coupon_code: เลขคูปอง
+        created_at: วันที่สั่งสินค้า
+        email: อีเมลของลูกค้า
+        ip_address: หลายเลขไอพี
+        item_total: รวม
+        number: หมายเลข
+        payment_state: จังหวัด
+        shipment_state: จังหวัด
+        special_instructions: ข้อแนะนำเพิ่มเติม
+        state: จังหวัด
+        total: รวม
+        additional_tax_total: ภาษี
+        approved_at:
+        approver_id:
+        canceled_at:
+        canceler_id:
+        included_tax_total:
+        shipment_total: ค่าจัดส่ง
       spree/order/bill_address:
-        address1: "ชื่อถนนในใบเสร็จ"
-        city: "ชื่อตำบลในใบเสร็จ"
-        firstname: "ชื่อในใบเสร็จ"
-        lastname: "นามสกุลในใบเสร็จ"
-        phone: "เบอร์โทรศัพท์ในใบเสร็จ"
-        state: "ชื่อจังหวัดในใบเสร็จ"
-        zipcode: "รหัสไปรษณีย์ในใบเสร็จ"
+        address1: ชื่อถนนในใบเสร็จ
+        city: ชื่อตำบลในใบเสร็จ
+        firstname: ชื่อในใบเสร็จ
+        lastname: นามสกุลในใบเสร็จ
+        phone: เบอร์โทรศัพท์ในใบเสร็จ
+        state: ชื่อจังหวัดในใบเสร็จ
+        zipcode: รหัสไปรษณีย์ในใบเสร็จ
       spree/order/ship_address:
-        address1: "ถนนที่จัดส่ง"
-        city: "จังหวัดที่จัดส่ง"
-        firstname: "ชื่อผู้รับ"
-        lastname: "นามสกุลผู้รับ"
-        phone: "เบอร์โทรศัพท์ผู้รับ"
-        state: "จังหวัดที่จัดส่ง"
-        zipcode: "รหัสไปรษณีย์ผู้รับ"
+        address1: ถนนที่จัดส่ง
+        city: จังหวัดที่จัดส่ง
+        firstname: ชื่อผู้รับ
+        lastname: นามสกุลผู้รับ
+        phone: เบอร์โทรศัพท์ผู้รับ
+        state: จังหวัดที่จัดส่ง
+        zipcode: รหัสไปรษณีย์ผู้รับ
       spree/payment:
-        amount: "จำนวน"
+        amount: จำนวน
+        number:
+        response_code:
+        state: สถานะการชำระเงิน
       spree/payment_method:
-        name: "ชื่อ"
+        name: ชื่อ
+        active: ใช้งาน
+        auto_capture:
+        description: รายละเอียด
+        display_on: แสดง
+        type: ผู้ให้บริการ
       spree/product:
-        available_on: "พร้อมเมื่อ"
-        cost_currency: "ราคาอัตราแลกเปลี่ยน"
-        cost_price: "ราคา"
-        description: "รายละเอียด"
-        master_price: "ราคาจริง"
-        name: "ชื่อ"
-        on_hand: "มีสินค้า"
-        shipping_category: "ประเภทการส่งสินค้า"
-        tax_category: "ประเภทภาษี"
+        available_on: พร้อมเมื่อ
+        cost_currency: ราคาอัตราแลกเปลี่ยน
+        cost_price: ราคา
+        description: รายละเอียด
+        master_price: ราคาจริง
+        name: ชื่อ
+        on_hand: มีสินค้า
+        shipping_category: ประเภทการส่งสินค้า
+        tax_category: ประเภทภาษี
+        depth: ลึก
+        height: สูง
+        meta_description: Meta Description
+        meta_keywords: Meta Keywords
+        meta_title:
+        price: ราคาหลัก
+        promotionable:
+        slug:
+        weight: น้ำหนัก
+        width: กว้าง
       spree/promotion:
-        advertise: "โฆษณา"
-        code: "หมายเลข"
-        description: "รายละเอียด"
+        advertise: โฆษณา
+        code: หมายเลข
+        description: รายละเอียด
         event_name: Event Name
-        expires_at: "วันหมดอายุ"
-        name: "ชื่อ"
+        expires_at: วันหมดอายุ
+        name: ชื่อ
         path: Path
-        starts_at: "เริ่มเมื่อ"
-        usage_limit: "จำกัดจำนวน"
+        starts_at: เริ่มเมื่อ
+        usage_limit: จำกัดจำนวน
       spree/promotion_category:
         name:
       spree/property:
-        name: "ชื่อ"
-        presentation: "การแสดงผล"
+        name: ชื่อ
+        presentation: การแสดงผล
       spree/prototype:
-        name: "ชื่อ"
+        name: ชื่อ
       spree/return_authorization:
-        amount: "จำนวน"
+        amount: จำนวน
+        pre_tax_total:
       spree/role:
-        name: "ชื่อ"
+        name: ชื่อ
       spree/state:
-        abbr: "ตัวย่อ"
-        name: "ชื่อ"
+        abbr: ตัวย่อ
+        name: ชื่อ
       spree/state_change:
         state_changes:
         state_from:
@@ -124,34 +158,155 @@ th:
         seo_title:
         url:
       spree/tax_category:
-        description: "รายละเอียด"
-        name: "ชื่อ"
+        description: รายละเอียด
+        name: ชื่อ
+        is_default: ค่าเริ่มต้น
+        tax_code:
       spree/tax_rate:
-        amount: "อัตรา"
-        included_in_price: "รวมในราคา"
-        show_rate_in_label: "แสดงอัตรา"
+        amount: อัตรา
+        included_in_price: รวมในราคา
+        show_rate_in_label: แสดงอัตรา
+        name: ชื่อ
       spree/taxon:
-        name: "ชื่อ"
+        name: ชื่อ
         permalink: Permalink
-        position: "ตำแหน่ง"
+        position: ตำแหน่ง
+        description: รายละเอียด
+        icon: ไอค่อน
+        meta_description: Meta Description
+        meta_keywords: Meta Keywords
+        meta_title:
       spree/taxonomy:
-        name: "ชื่อ"
+        name: ชื่อ
       spree/user:
-        email: "อีเมล"
-        password: "รหัสผ่าน"
-        password_confirmation: "ยืนยันรหัสผ่าน"
+        email: อีเมล
+        password: รหัสผ่าน
+        password_confirmation: ยืนยันรหัสผ่าน
       spree/variant:
-        cost_currency: "อัตราแลกเปลี่ยน"
-        cost_price: "ราคา"
-        depth: "ความลึก"
-        height: "ความสูง"
-        price: "ราคา"
+        cost_currency: อัตราแลกเปลี่ยน
+        cost_price: ราคา
+        depth: ความลึก
+        height: ความสูง
+        price: ราคา
         sku: SKU
-        weight: "น้ำหนัก"
-        width: "ความกว้าง"
+        weight: น้ำหนัก
+        width: ความกว้าง
       spree/zone:
-        description: "รายละเอียด"
-        name: "ชื่อ"
+        description: รายละเอียด
+        name: ชื่อ
+        default_tax: ค่าโซนภาษีเริ่มต้น
+      spree/adjustment:
+        adjustable:
+        amount: รวม
+        label: รายละเอียด
+        name: ชื่อ
+        state: จังหวัด
+        adjustment_reason_id: เหตุผล
+      spree/adjustment_reason:
+        active: ใช้งาน
+        code: Code
+        name: ชื่อ
+        state: จังหวัด
+      spree/carton:
+        tracking: Tracking
+      spree/customer_return:
+        number:
+        pre_tax_total:
+        total: จำนวน
+        reimbursement_status:
+        name: ชื่อ
+      spree/image:
+        alt: ข้อความอื่นๆ
+        attachment: ชื่อไฟล์
+      spree/legacy_user:
+        email: อีเมล
+        password: รหัสผ่าน
+        password_confirmation: ยืนยันรหัสผ่าน
+      spree/option_value:
+        name: ชื่อ
+        presentation: แสดง
+      spree/product_property:
+        value: ค่า
+      spree/refund:
+        amount: รวม
+        description: รายละเอียด
+        refund_reason_id: เหตุผล
+      spree/refund_reason:
+        active: ใช้งาน
+        name: ชื่อ
+        code: Code
+      spree/reimbursement:
+        number: หมายเลข
+        reimbursement_status: สถานะ
+        total: จำนวน
+      spree/reimbursement/credit:
+        amount: รวม
+      spree/reimbursement_type:
+        name: ชื่อ
+        type: ประเภท
+      spree/return_item:
+        acceptance_status:
+        acceptance_status_errors:
+        charged:
+        exchange_variant:
+        inventory_unit_state: จังหวัด
+        override_reimbursement_type_id:
+        preferred_reimbursement_type_id:
+        reception_status:
+        return_reason: เหตุผล
+        total: จำนวน
+      spree/return_reason:
+        name: ชื่อ
+        active: ใช้งาน
+        memo:
+        number: RMA Number
+        state: จังหวัด
+      spree/shipping_category:
+        name: ชื่อ
+      spree/shipment:
+        tracking: Tracking Number
+      spree/shipping_method:
+        admin_name:
+        code: Code
+        display_on: แสดง
+        name: ชื่อ
+        tracking_url: Tracking URL
+      spree/shipping_rate:
+        tax_rate: อัตราภาษีTax Rate
+        amount: รวม
+      spree/store_credit:
+        amount: รวม
+        memo:
+      spree/store_credit_event:
+        action: ทำการ
+      spree/stock_item:
+        count_on_hand: จำนวนในมือ
+      spree/stock_location:
+        admin_name:
+        active: ใช้งาน
+        address1: ที่อยู่
+        address2: ที่อยู่ (ต่อ)
+        backorderable_default:
+        city: เขต หรือ อำเภอ
+        code: Code
+        country_id: ประเทศ
+        default: ค่าเริ่มต้น
+        internal_name:
+        name: ชื่อ
+        phone: เบอร์โทรศัพท์
+        propagate_all_variants:
+        state_id: จังหวัด
+        zipcode: รหัสไปรษณีย์
+      spree/stock_movement:
+        action: ทำการ
+        quantity: จำนวน
+      spree/stock_transfer:
+        created_at: สร้างเมื่อ
+        description: รายละเอียด
+        tracking_number: Tracking Number
+      spree/tracker:
+        analytics_id: Analytics ID
+        active: ใช้งาน
     errors:
       models:
         spree/calculator/tiered_flat_rate:
@@ -200,191 +355,247 @@ th:
               cannot_destroy_default_store:
     models:
       spree/address:
-        one: "ที่อยู่"
-        other: "ที่อยู่"
+        one: ที่อยู่
+        other: ที่อยู่
       spree/country:
-        one: "ประเทศ"
-        other: "ประเทศ"
+        one: ประเทศ
+        other: ประเทศ
       spree/credit_card:
-        one: "บัตรเครดิต"
-        other: "บัตรเครดิต"
+        one: บัตรเครดิต
+        other: บัตรเครดิต
       spree/customer_return:
+        one:
+        other:
       spree/inventory_unit:
-        one: "จำนวนในคลัง"
-        other: "จำนวนในคลัง"
+        one: จำนวนในคลัง
+        other: จำนวนในคลัง
       spree/line_item:
         one: Line Item
         other: Line Items
       spree/option_type:
+        one: ประเภทตัวเลือก
+        other: ประเภทตัวเลือก
       spree/option_value:
+        one: ค่าของตัวเลือก
+        other: ค่าของตัวเลือก
       spree/order:
-        one: "สั่งซื้อ"
-        other: "สั่งซื้อ"
+        one: สั่งซื้อ
+        other: สั่งซื้อ
       spree/payment:
-        one: "ชำระ"
-        other: "ชำระ"
+        one: ชำระ
+        other: ชำระ
       spree/payment_method:
+        one: วิธีชำระเงิน
+        other: วิธีชำระเงิน
       spree/product:
-        one: "สินค้า"
-        other: "สินค้า"
+        one: สินค้า
+        other: สินค้า
       spree/promotion:
+        one: โปรโมชั่น
+        other: โปรโมชั่น
       spree/promotion_category:
+        other:
       spree/property:
-        one: "คุณสมบัติ"
-        other: "คุณสมบัติ"
+        one: คุณสมบัติ
+        other: คุณสมบัติ
       spree/prototype:
         one: Prototype
         other: Prototypes
       spree/refund_reason:
+        other:
       spree/reimbursement:
+        one:
+        other:
       spree/reimbursement_type:
+        other:
       spree/return_authorization:
-        one: "รายการคืน"
-        other: "รายการคืน"
+        one: รายการคืน
+        other: รายการคืน
       spree/return_authorization_reason:
       spree/role:
-        one: "หน้าที่"
-        other: "หน้าที่"
+        one: หน้าที่
+        other: หน้าที่
       spree/shipment:
-        one: "การส่งสินค้า"
-        other: "การส่งสินค้า"
+        one: การส่งสินค้า
+        other: การส่งสินค้า
       spree/shipping_category:
-        one: "ประเภทการจัดส่ง"
-        other: "ประเภทการจัดส่ง"
+        one: ประเภทการจัดส่ง
+        other: ประเภทการจัดส่ง
       spree/shipping_method:
+        one: วิธีการจัดส่ง
+        other: วิธีการจัดส่ง
       spree/state:
-        one: "จังหวัด"
-        other: "จังหวัด"
+        one: จังหวัด
+        other: จังหวัด
       spree/state_change:
       spree/stock_location:
+        one: สถานที่ของคลังสินค้า
+        other: สถานที่ของคลังสินค้า
       spree/stock_movement:
+        other: สินค้าเคลื่อนไหว
       spree/stock_transfer:
+        one: ย้ายสินค้า
+        other: ย้ายสินค้า
       spree/tax_category:
-        one: "ประเภทภาษี"
-        other: "ประเภทภาษี"
+        one: ประเภทภาษี
+        other: ประเภทภาษี
       spree/tax_rate:
-        one: "อัตราภาษีTax Rate"
-        other: "อัตราภาษี"
+        one: อัตราภาษีTax Rate
+        other: อัตราภาษี
       spree/taxon:
+        one: Taxon
+        other: Taxons
       spree/taxonomy:
+        one: Taxonomy
+        other: Taxonomies
       spree/tracker:
+        other: Analytics Trackers
       spree/user:
-        one: "ผู้ใช้งาน"
-        other: "ผู้ใช้งาน"
+        one: ผู้ใช้งาน
+        other: ผู้ใช้งาน
       spree/variant:
-        one: "ตัวแปร"
-        other: "ตัวแปร"
+        one: ตัวแปร
+        other: ตัวแปร
       spree/zone:
-        one: "เขต"
-        other: "เขต"
+        one: เขต
+        other: เขต
+      spree/adjustment:
+        one: แก้ไขรายการ
+        other: แก้ไขรายการ
+      spree/calculator:
+        one: เครื่องคิดเลข
+      spree/legacy_user:
+        one: ผู้ใช้
+        other: ผู้ใช้
+      spree/log_entry:
+        other:
+      spree/product_property:
+        other: สรรพคุณของสินค้า
+      spree/refund:
+        one: คืนเงิน
+        other:
+      spree/store_credit_category:
+        one: ชนิด
+        other: หมวดหมู่
   devise:
     confirmations:
-      confirmed: "บัญชีของคุณได้ถูกยืนยันแล้ว ขณะนี้คุณได้เข้าระบบเรียบร้อย"
-      send_instructions: "คุณจะได้รับวิธีการยืนยันบัญชีของคุณที่ทางเราส่งไปทางอีเมลในอีกไม่กี่นาทีข้างหน้า"
+      confirmed: บัญชีของคุณได้ถูกยืนยันแล้ว ขณะนี้คุณได้เข้าระบบเรียบร้อย
+      send_instructions: คุณจะได้รับวิธีการยืนยันบัญชีของคุณที่ทางเราส่งไปทางอีเมลในอีกไม่กี่นาทีข้างหน้า
     failure:
-      inactive: "บัญชีของคุณยังไม่ได้รับการยืนยัน"
-      invalid: "อีเมลหรือรหัสผ่านไม่ถูกต้อง"
-      invalid_token: "รหัส token ไม่ถูกต้อง"
-      locked: "บัญชีของคุณถูกระงับ"
-      timeout: "เซสชั่นของคุณนั้นหมดอายุ กรุณาเข้าระบบใหม่อีกครั้ง"
-      unauthenticated: "คุณต้องเข้าระบบหรือสมัครสมาชิกก่อนเพื่อทำรายการต่อไป"
-      unconfirmed: "คุณต้องยืนยันบัญชีคุณก่อนถึงจะสามารถทำรายการต่อไปได้"
+      inactive: บัญชีของคุณยังไม่ได้รับการยืนยัน
+      invalid: อีเมลหรือรหัสผ่านไม่ถูกต้อง
+      invalid_token: รหัส token ไม่ถูกต้อง
+      locked: บัญชีของคุณถูกระงับ
+      timeout: เซสชั่นของคุณนั้นหมดอายุ กรุณาเข้าระบบใหม่อีกครั้ง
+      unauthenticated: คุณต้องเข้าระบบหรือสมัครสมาชิกก่อนเพื่อทำรายการต่อไป
+      unconfirmed: คุณต้องยืนยันบัญชีคุณก่อนถึงจะสามารถทำรายการต่อไปได้
     mailer:
       confirmation_instructions:
-        subject: "วิธีการยืนยัน"
+        subject: วิธีการยืนยัน
       reset_password_instructions:
-        subject: "วิธีการเปลี่ยนรหัสผ่านใหม่"
+        subject: วิธีการเปลี่ยนรหัสผ่านใหม่
       unlock_instructions:
-        subject: "วิธีการปลดล๊อกบัญชี"
+        subject: วิธีการปลดล๊อกบัญชี
     oauth_callbacks:
-      failure: "ไม่สามารถให้สิทธิคุณได้จาก %{kind} เพราะ %{reason}"
-      success: "ได้รับสิทธิจาก %{kind} ในบัญชี"
+      failure: ไม่สามารถให้สิทธิคุณได้จาก %{kind} เพราะ %{reason}
+      success: ได้รับสิทธิจาก %{kind} ในบัญชี
     unlocks:
-      send_instructions: "คุณจะได้รับอีเมลวิธีการปลดล๊อกบัญชีของคุณภายในไม่กี่นาที"
-      unlocked: "บัญชีของคุณนั้นได้ปลดล๊อกแล้ว ได้เข้าระบบเป็นที่เรียบร้อย"
+      send_instructions: คุณจะได้รับอีเมลวิธีการปลดล๊อกบัญชีของคุณภายในไม่กี่นาที
+      unlocked: บัญชีของคุณนั้นได้ปลดล๊อกแล้ว ได้เข้าระบบเป็นที่เรียบร้อย
     user_passwords:
       user:
-        cannot_be_blank: "กรุณากรอกรหัสผ่าน"
-        send_instructions: "คุณจะได้รับอีเมลวิธีการเปลี่ยนรหัสผ่านของคุณภายในไม่กี่นาที"
-        updated: "เราได้ทำการเปลี่ย���รหัสผ่านของคุณแล้ว ได้เข้าระบบเป็นที่เรียบร้อย"
+        cannot_be_blank: กรุณากรอกรหัสผ่าน
+        send_instructions: คุณจะได้รับอีเมลวิธีการเปลี่ยนรหัสผ่านของคุณภายในไม่กี่นาที
+        updated: เราได้ทำการเปลี่ย���รหัสผ่านของคุณแล้ว ได้เข้าระบบเป็นที่เรียบร้อย
     user_registrations:
-      destroyed: "ลาก่อน! บัญชีของคุณนั้นได้ทำการยกเลิกเป็นที่เรียบร้อย เราหวังว่าจะได้รับใช้คุณใหม่ในโอกาสต่อไป"
-      inactive_signed_up: "คุณได้ทำการสมัครเป็นที่เรียบร้อย อย่างไรก็ตาม เราไม่สามารถให้คุณเข้าระบบได้เนื่องจากบัญชีของคุณนั้น %{reason}"
-      signed_up: "ยินดีต้อนรับ! คุณได้สมัครสมาชิกเป็นที่เรียบร้อย"
-      updated: "คุณได้แก้ไขบัญชีคุณเป็นที่เรียบร้อย"
+      destroyed: ลาก่อน! บัญชีของคุณนั้นได้ทำการยกเลิกเป็นที่เรียบร้อย เราหวังว่าจะได้รับใช้คุณใหม่ในโอกาสต่อไป
+      inactive_signed_up: คุณได้ทำการสมัครเป็นที่เรียบร้อย อย่างไรก็ตาม เราไม่สามารถให้คุณเข้าระบบได้เนื่องจากบัญชีของคุณนั้น %{reason}
+      signed_up: ยินดีต้อนรับ! คุณได้สมัครสมาชิกเป็นที่เรียบร้อย
+      updated: คุณได้แก้ไขบัญชีคุณเป็นที่เรียบร้อย
     user_sessions:
-      signed_in: "เข้าสู่ระบบเรียบร้อย"
-      signed_out: "ออกจากระบบเรียบร้อย"
+      signed_in: เข้าสู่ระบบเรียบร้อย
+      signed_out: ออกจากระบบเรียบร้อย
   errors:
     messages:
-      already_confirmed: "ได้ทำการยืนยันแล้ว"
-      not_found: "ไม่พบ"
-      not_locked: "ไม่ได้ล๊อก"
-      not_saved: "พบ %{count} ข้อผิดพลาดที่ทำให้ %{resource} ไม่สามารถบันทึกได้"
+      already_confirmed: ได้ทำการยืนยันแล้ว
+      not_found: ไม่พบ
+      not_locked: ไม่ได้ล๊อก
+      not_saved: พบ %{count} ข้อผิดพลาดที่ทำให้ %{resource} ไม่สามารถบันทึกได้
   spree:
-    abbreviation: "คำย่อ"
+    abbreviation: คำย่อ
     accept:
     acceptance_errors:
     acceptance_status:
     accepted:
-    account: "บัญชีผู้ใช้"
-    account_updated: "ปรับปรุงบัญชีผู้ใช้แล้ว"
-    action: "ทำการ"
+    account: บัญชีผู้ใช้
+    account_updated: ปรับปรุงบัญชีผู้ใช้แล้ว
+    action: ทำการ
     actions:
-      cancel: "ยกเลิก"
-      continue: "ต่อไป"
-      create: "สร้าง"
-      destroy: "ทำลาย"
-      edit: "แก้ไข"
-      list: "แสดงรายการ"
-      listing: "รายการ"
-      new: "สร้าง"
+      cancel: ยกเลิก
+      continue: ต่อไป
+      create: สร้าง
+      destroy: ทำลาย
+      edit: แก้ไข
+      list: แสดงรายการ
+      listing: รายการ
+      new: สร้าง
       refund:
-      save: "บันทึก"
-      update: "ปรับปรุง"
-    activate: "เริ่มใช้งาน"
-    active: "ใช้งาน"
-    add: "เพิ่ม"
-    add_action_of_type: "เพิ่มประเภท"
-    add_country: "เพิ่มประเทศ"
+      save: บันทึก
+      update: ปรับปรุง
+      add: เพิ่ม
+      delete: ลบ
+      remove: ลบ
+      ship: ส่ง
+      split: แยก
+    activate: เริ่มใช้งาน
+    active: ใช้งาน
+    add: เพิ่ม
+    add_action_of_type: เพิ่มประเภท
+    add_country: เพิ่มประเทศ
     add_coupon_code:
-    add_new_header: "เพิ่ม Header"
-    add_new_style: "เพิ่ม Style"
-    add_one: "เพิ่ม"
-    add_option_value: "เพิ่มรายการตัวเลือก"
-    add_product: "เพิ่มสินค้า"
-    add_product_properties: "เพิ่มคุณสมบัติ"
-    add_rule_of_type: "เพิ่มกฏของประเภท"
-    add_state: "เพิ่มจังหวัด"
-    add_stock: "เพิ่มสต็อก"
-    add_stock_management: "เพิ่มการจัดการสต็อก"
-    add_to_cart: "เพิ่มลงตะกร้า"
-    add_variant: "เพิ่มตัวแปร"
-    additional_item: "ราคาเพิ่มเติม"
-    address1: "ที่อยู่"
-    address2: "ที่อยู่ (เพิ่มเติม)"
+    add_new_header: เพิ่ม Header
+    add_new_style: เพิ่ม Style
+    add_one: เพิ่ม
+    add_option_value: เพิ่มรายการตัวเลือก
+    add_product: เพิ่มสินค้า
+    add_product_properties: เพิ่มคุณสมบัติ
+    add_rule_of_type: เพิ่มกฏของประเภท
+    add_state: เพิ่มจังหวัด
+    add_stock: เพิ่มสต็อก
+    add_stock_management: เพิ่มการจัดการสต็อก
+    add_to_cart: เพิ่มลงตะกร้า
+    add_variant: เพิ่มตัวแปร
+    additional_item: ราคาเพิ่มเติม
+    address1: ที่อยู่
+    address2: ที่อยู่ (เพิ่มเติม)
     adjustable:
-    adjustment: "แก้ไขรายการ"
-    adjustment_amount: "จำนวน"
-    adjustment_successfully_closed: "รายการแก้ไขได้ทำการปิดเป็นที่เรียบร้อย"
-    adjustment_successfully_opened: "รายการแก้ไขได้ทำการเปิดเป็นที่เรียบร้อย"
-    adjustment_total: "ยอดรวมรายการที่แก้ไข"
-    adjustments: "แก้ไขรายการ"
+    adjustment: แก้ไขรายการ
+    adjustment_amount: จำนวน
+    adjustment_successfully_closed: รายการแก้ไขได้ทำการปิดเป็นที่เรียบร้อย
+    adjustment_successfully_opened: รายการแก้ไขได้ทำการเปิดเป็นที่เรียบร้อย
+    adjustment_total: ยอดรวมรายการที่แก้ไข
+    adjustments: แก้ไขรายการ
     admin:
       tab:
-        configuration: "ตั้งค่า"
+        configuration: ตั้งค่า
         option_types:
-        orders: "สั่งซื้อ"
-        overview: "ภาพรวม"
-        products: "สินค้า"
-        promotions: "โปรโมชั่น"
+        orders: สั่งซื้อ
+        overview: ภาพรวม
+        products: สินค้า
+        promotions: โปรโมชั่น
         promotion_categories:
         properties:
         prototypes:
-        reports: "รายงาน"
+        reports: รายงาน
         taxonomies:
         taxons:
-        users: "ผู้ใช้"
+        users: ผู้ใช้
+        checkout: สั่งซื้อ
+        general: เบื้องต้น
+        payments: รายการชำระเงิน
+        settings: ตั้งค่า
+        shipping: ส่ง
+        stock:
       user:
         account:
         addresses:
@@ -394,196 +605,196 @@ th:
         order_num:
         orders:
         user_information:
-    administration: "การจัดการ"
+    administration: การจัดการ
     advertise:
-    agree_to_privacy_policy: "ตกลงในนโยบายความเป็นส่วนตัว"
-    agree_to_terms_of_service: "ตกลงในข้อตกลงบริการ"
-    all: "ทั้งหมด"
-    all_adjustments_closed: "ทุกรายการแก้ไขนั้นได้ปิดลงแล้ว!"
-    all_adjustments_opened: "ทุกรายการแก้ไขนั้้นได้เปิดแล้ว!"
-    all_departments: "ทุกแผนก"
+    agree_to_privacy_policy: ตกลงในนโยบายความเป็นส่วนตัว
+    agree_to_terms_of_service: ตกลงในข้อตกลงบริการ
+    all: ทั้งหมด
+    all_adjustments_closed: ทุกรายการแก้ไขนั้นได้ปิดลงแล้ว!
+    all_adjustments_opened: ทุกรายการแก้ไขนั้้นได้เปิดแล้ว!
+    all_departments: ทุกแผนก
     all_items_have_been_returned:
-    allow_ssl_in_development_and_test: "อนุญาตให้ใช้ SSL เมื่ออยู่ในโหมดของการพัฒนาและทดสอบ"
-    allow_ssl_in_production: "อนุญาต SSL ให้ทำงานบน Production"
-    allow_ssl_in_staging: "อนุณาต SSL ให้ทำงานบน Stagging"
-    already_signed_up_for_analytics: "คุณได้สมัครใช้งาน Spree Analytics"
-    alt_text: "ข้อความอื่นๆ"
-    alternative_phone: "เบอร์โทรอื่นๆ"
-    amount: "รวม"
+    allow_ssl_in_development_and_test: อนุญาตให้ใช้ SSL เมื่ออยู่ในโหมดของการพัฒนาและทดสอบ
+    allow_ssl_in_production: อนุญาต SSL ให้ทำงานบน Production
+    allow_ssl_in_staging: อนุณาต SSL ให้ทำงานบน Stagging
+    already_signed_up_for_analytics: คุณได้สมัครใช้งาน Spree Analytics
+    alt_text: ข้อความอื่นๆ
+    alternative_phone: เบอร์โทรอื่นๆ
+    amount: รวม
     analytics_desc_header_1: Spree Analytics
-    analytics_desc_header_2: "ข้อมูล analytics  ได้ผนวกไปยังหน้า Dashboard ของคุณ"
-    analytics_desc_list_1: "ได้ข้อมูลการสั่งซื้อในทันที"
-    analytics_desc_list_2: "ต้องการเฉพาะบัญชีฟรีของ Spree เพื่อใช้งาน"
-    analytics_desc_list_3: "ไม่ต้องติดตั้งโค๊ดใดๆ"
-    analytics_desc_list_4: "มันฟรีจริงๆนะ!"
+    analytics_desc_header_2: ข้อมูล analytics  ได้ผนวกไปยังหน้า Dashboard ของคุณ
+    analytics_desc_list_1: ได้ข้อมูลการสั่งซื้อในทันที
+    analytics_desc_list_2: ต้องการเฉพาะบัญชีฟรีของ Spree เพื่อใช้งาน
+    analytics_desc_list_3: ไม่ต้องติดตั้งโค๊ดใดๆ
+    analytics_desc_list_4: มันฟรีจริงๆนะ!
     analytics_trackers: Analytics Trackers
-    and: "และ"
+    and: และ
     approve:
     approved_at:
     approver:
-    are_you_sure: "แน่ใจหรือไม่"
-    are_you_sure_delete: "คุณแน่ใจที่จะลบข้อมูลนี้หรือไม่?"
-    associated_adjustment_closed: "รายการที่เกี่ยวข้อกับรายการปรับปรุงนั้นได้ปิดแล้ว และจะไม่นำมาคำนวนใหม่ คุณต้องการที่จะเปิดหรือไม่?"
-    at_symbol: '@'
-    authorization_failure: "การขออนุญาต ไม่สำเร็จ"
+    are_you_sure: แน่ใจหรือไม่
+    are_you_sure_delete: คุณแน่ใจที่จะลบข้อมูลนี้หรือไม่?
+    associated_adjustment_closed: รายการที่เกี่ยวข้อกับรายการปรับปรุงนั้นได้ปิดแล้ว และจะไม่นำมาคำนวนใหม่ คุณต้องการที่จะเปิดหรือไม่?
+    at_symbol: "@"
+    authorization_failure: การขออนุญาต ไม่สำเร็จ
     authorized:
     auto_capture:
-    available_on: "พร้อมเมื่อ"
+    available_on: พร้อมเมื่อ
     average_order_value:
     avs_response:
-    back: "กลับ"
+    back: กลับ
     back_end: Back End
     back_to_payment:
     back_to_resource_list:
     back_to_rma_reason_list:
-    back_to_store: "กลับไปหน้าร้าน"
-    back_to_users_list: "กลับไปยังรายการลูกค้า"
-    backorderable: "สามารถสั่งซื้อล่วงหน้าได้"
+    back_to_store: กลับไปหน้าร้าน
+    back_to_users_list: กลับไปยังรายการลูกค้า
+    backorderable: สามารถสั่งซื้อล่วงหน้าได้
     backorderable_default:
     backordered:
     backorders_allowed:
-    balance_due: "ยอดที่ต้องชำระ"
+    balance_due: ยอดที่ต้องชำระ
     base_amount:
     base_percent:
-    bill_address: "ที่อยู่บนใบเสร็จรับเงิน"
-    billing: "ใบเสร็จรับเงิน"
-    billing_address: "ที่อยู่บนใบเสร็จรับเงิน"
-    both: "ทั้งสอง"
+    bill_address: ที่อยู่บนใบเสร็จรับเงิน
+    billing: ใบเสร็จรับเงิน
+    billing_address: ที่อยู่บนใบเสร็จรับเงิน
+    both: ทั้งสอง
     calculated_reimbursements:
-    calculator: "เครื่องคิดเลข"
-    calculator_settings_warning: "หากคุณต้องการเปลี่ยนวิธีการคำนวน คุณต้องบันทึกก่อนถึงจะสามารถแก้ไขการคำนวนได้"
-    cancel: "ยกเลิก"
+    calculator: เครื่องคิดเลข
+    calculator_settings_warning: หากคุณต้องการเปลี่ยนวิธีการคำนวน คุณต้องบันทึกก่อนถึงจะสามารถแก้ไขการคำนวนได้
+    cancel: ยกเลิก
     canceled_at:
     canceler:
     cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: "คุณไม่สามารถชำระรายการสั่งซื้อได้เนื่องจากไม่ได้กำหนดวิธีชำระสินค้า"
-    cannot_create_returns: "ไม่สามารถทำรายการคืนสินาได้เนื่องจากยังไม่ได้ส่งสินค้าดังกล่าว"
-    cannot_perform_operation: "ไม่สามารถทำรายการที่ต้องการได้"
-    cannot_set_shipping_method_without_address: "ไม่สามารถตั้งค่าประเภทการจัดส่งได้จนกว่าจะได้รับรายละเอียดของลูกค้า"
+    cannot_create_payment_without_payment_methods: คุณไม่สามารถชำระรายการสั่งซื้อได้เนื่องจากไม่ได้กำหนดวิธีชำระสินค้า
+    cannot_create_returns: ไม่สามารถทำรายการคืนสินาได้เนื่องจากยังไม่ได้ส่งสินค้าดังกล่าว
+    cannot_perform_operation: ไม่สามารถทำรายการที่ต้องการได้
+    cannot_set_shipping_method_without_address: ไม่สามารถตั้งค่าประเภทการจัดส่งได้จนกว่าจะได้รับรายละเอียดของลูกค้า
     capture: capture
     capture_events:
-    card_code: "รหัสบัตร"
-    card_number: "หมายเลขบัตร"
+    card_code: รหัสบัตร
+    card_number: หมายเลขบัตร
     card_type:
-    card_type_is: "ชนิดของบัตร"
-    cart: "ตะกร้าสินค้า"
+    card_type_is: ชนิดของบัตร
+    cart: ตะกร้าสินค้า
     cart_subtotal:
-    categories: "หมวดหมู่"
-    category: "ชนิด"
+    categories: หมวดหมู่
+    category: ชนิด
     charged:
-    check_for_spree_alerts: "ตรวจสอบการแจ้งเตือน Spree"
-    checkout: "สั่งซื้อ"
-    choose_a_customer: "เลือกลูกค้า"
+    check_for_spree_alerts: ตรวจสอบการแจ้งเตือน Spree
+    checkout: สั่งซื้อ
+    choose_a_customer: เลือกลูกค้า
     choose_a_taxon_to_sort_products_for:
-    choose_currency: "เลือกสกุลเงิน"
-    choose_dashboard_locale: "เลือกภาษาของ Dashboard"
+    choose_currency: เลือกสกุลเงิน
+    choose_dashboard_locale: เลือกภาษาของ Dashboard
     choose_location:
-    city: "เขต หรือ อำเภอ"
+    city: เขต หรือ อำเภอ
     clear_cache:
     clear_cache_ok:
     clear_cache_warning:
     click_and_drag_on_the_products_to_sort_them:
     clone: Clone
-    close: "ปิด"
-    close_all_adjustments: "ปิดรายการปรับปรุงทั้งหมด"
+    close: ปิด
+    close_all_adjustments: ปิดรายการปรับปรุงทั้งหมด
     code: Code
-    company: "บริษัท"
-    complete: "เสร็จสิ้น"
-    configuration: "จัดการระบบ"
-    configurations: "รายการจัดการ"
-    confirm: "ยืนยันรหัสผ่าน"
-    confirm_delete: "ยืนยันการลบ"
-    confirm_password: "ยืนยันรหัสผ่าน"
-    continue: "ดำเนินการต่อ"
-    continue_shopping: "เลือกซื้อสินค้าต่อ"
-    cost_currency: "ราคาสกุลเงิน"
+    company: บริษัท
+    complete: เสร็จสิ้น
+    configuration: จัดการระบบ
+    configurations: รายการจัดการ
+    confirm: ยืนยันรหัสผ่าน
+    confirm_delete: ยืนยันการลบ
+    confirm_password: ยืนยันรหัสผ่าน
+    continue: ดำเนินการต่อ
+    continue_shopping: เลือกซื้อสินค้าต่อ
+    cost_currency: ราคาสกุลเงิน
     cost_price: Cost Price
-    could_not_connect_to_jirafe: "ไม่สามารถเชื่อมต่อกับ Jirafe เพื่อรับข้อมูลได้ ระบบจะทดลองเชื่อมต่อใหม่อีกครั้ง"
+    could_not_connect_to_jirafe: ไม่สามารถเชื่อมต่อกับ Jirafe เพื่อรับข้อมูลได้ ระบบจะทดลองเชื่อมต่อใหม่อีกครั้ง
     could_not_create_customer_return:
-    could_not_create_stock_movement: "เกิดปัญหาขึ้นระหว่างทำการเคลื่อนย้ายสินค้า กรุณาลองใหม่อีกครั้ง"
-    count_on_hand: "จำนวนในมือ"
-    countries: "ประเทศ"
-    country: "ประเทศ"
-    country_based: "ยีดประเทศเป็นหลัก"
-    country_name: "ชื่อ"
+    could_not_create_stock_movement: เกิดปัญหาขึ้นระหว่างทำการเคลื่อนย้ายสินค้า กรุณาลองใหม่อีกครั้ง
+    count_on_hand: จำนวนในมือ
+    countries: ประเทศ
+    country: ประเทศ
+    country_based: ยีดประเทศเป็นหลัก
+    country_name: ชื่อ
     country_names:
       CA:
       FRA:
       ITA:
       US:
-    coupon: "คูปอง"
-    coupon_code: "หมายเลขคูปอง"
-    coupon_code_already_applied: "คูปองใบนี้ได้ถูกใช้ในรายการสั่งซื้อนี้แล้ว"
-    coupon_code_applied: "คูปองใบนี้ได้ถูกใช้สิทธิร่วมกับรายการสั่งซื้อของคุณเป็นที่เรียบร้อย"
-    coupon_code_better_exists: "คูปองที่ได้ใช้นั้นทำให้ราคาถูกลง"
-    coupon_code_expired: "คูปองหมดอายุแล้ว"
-    coupon_code_max_usage: "คูปองได้ถูกใช้เกินกำหนดแล้ว"
-    coupon_code_not_eligible: "คูปองนี้ไม่สามารถใช้กับรายการสั่งซื้อดังกล่าวได้"
-    coupon_code_not_found: "ไม่พบหมายเลขคูปองนี้ กรุณาลองใหม่อีกครั้ง"
+    coupon: คูปอง
+    coupon_code: หมายเลขคูปอง
+    coupon_code_already_applied: คูปองใบนี้ได้ถูกใช้ในรายการสั่งซื้อนี้แล้ว
+    coupon_code_applied: คูปองใบนี้ได้ถูกใช้สิทธิร่วมกับรายการสั่งซื้อของคุณเป็นที่เรียบร้อย
+    coupon_code_better_exists: คูปองที่ได้ใช้นั้นทำให้ราคาถูกลง
+    coupon_code_expired: คูปองหมดอายุแล้ว
+    coupon_code_max_usage: คูปองได้ถูกใช้เกินกำหนดแล้ว
+    coupon_code_not_eligible: คูปองนี้ไม่สามารถใช้กับรายการสั่งซื้อดังกล่าวได้
+    coupon_code_not_found: ไม่พบหมายเลขคูปองนี้ กรุณาลองใหม่อีกครั้ง
     coupon_code_unknown_error:
-    create: "สร้าง"
-    create_a_new_account: "สร้างบัญชีผู้ใช้ใหม่"
+    create: สร้าง
+    create_a_new_account: สร้างบัญชีผู้ใช้ใหม่
     create_new_order:
     create_reimbursement:
-    created_at: "สร้างเมื่อ"
-    credit: "เครดิต"
-    credit_card: "บัตรเครดิต"
-    credit_cards: "บัตรเครดิต"
-    credit_owed: "ค้างเครดิตอยู่"
+    created_at: สร้างเมื่อ
+    credit: เครดิต
+    credit_card: บัตรเครดิต
+    credit_cards: บัตรเครดิต
+    credit_owed: ค้างเครดิตอยู่
     credits:
-    currency: "สกุลเงิน"
-    currency_decimal_mark: "จุดทศนิยมของสกุลเงิน"
-    currency_settings: "ตั้งค่าสกุลเงิน"
-    currency_symbol_position: "ใส่เครื่องหมายสกุลเงินก่อนหรือหลังจำนวน?"
-    currency_thousands_separator: "ตัวคั่นทุกหนึ่งพัน"
-    current: "ขณะนี้"
-    current_promotion_usage: "ใช้อยู่: %{count}"
-    customer: "ลูกค้า"
-    customer_details: "รายละเอียดลูกค้า"
-    customer_details_updated: "ได้ทำการปรับปรุงรายละเอียดของลูกค้าแล้ว"
+    currency: สกุลเงิน
+    currency_decimal_mark: จุดทศนิยมของสกุลเงิน
+    currency_settings: ตั้งค่าสกุลเงิน
+    currency_symbol_position: ใส่เครื่องหมายสกุลเงินก่อนหรือหลังจำนวน?
+    currency_thousands_separator: ตัวคั่นทุกหนึ่งพัน
+    current: ขณะนี้
+    current_promotion_usage: 'ใช้อยู่: %{count}'
+    customer: ลูกค้า
+    customer_details: รายละเอียดลูกค้า
+    customer_details_updated: ได้ทำการปรับปรุงรายละเอียดของลูกค้าแล้ว
     customer_return:
     customer_returns:
-    customer_search: "ค้นหาลูกค้า"
+    customer_search: ค้นหาลูกค้า
     cut: Cut
     cvv_response:
     dash:
       jirafe:
         app_id: App ID
         app_token: App Token
-        currently_unavailable: "ไม่สามารถใช้ Jirafe ได้ในขณะนี้ Spree จะลองเชื่อมต่อใหม่ภายหลัง"
+        currently_unavailable: ไม่สามารถใช้ Jirafe ได้ในขณะนี้ Spree จะลองเชื่อมต่อใหม่ภายหลัง
         explanation: Field ด้านล่างอาจสร้างขึ้นมาหากคุณเลือกที่จะลงทะเบียน Jirafe จากหน้า Dashboard ของ admin
-        header: "ตั้งค่า Jarafe Analytics"
+        header: ตั้งค่า Jarafe Analytics
         site_id: Site ID
         token: Token
-      jirafe_settings_updated: "ค่าของ Jirafe ได้ถูกปรับปรุงแล้ว"
-    date: "วันที่"
-    date_completed: "วันที่เสร็จสิ้น"
+      jirafe_settings_updated: ค่าของ Jirafe ได้ถูกปรับปรุงแล้ว
+    date: วันที่
+    date_completed: วันที่เสร็จสิ้น
     date_picker:
       first_day:
       format: "%Y/%m/%d"
       js_format: yy/mm/dd
-    date_range: "ช่วงวันที่"
-    default: "ค่าเริ่มต้น"
+    date_range: ช่วงวันที่
+    default: ค่าเริ่มต้น
     default_refund_amount:
-    default_tax: "ค่าภาษีเริ่มต้น"
-    default_tax_zone: "ค่าโซนภาษีเริ่มต้น"
-    delete: "ลบ"
+    default_tax: ค่าภาษีเริ่มต้น
+    default_tax_zone: ค่าโซนภาษีเริ่มต้น
+    delete: ลบ
     deleted_variants_present:
-    delivery: "จัดส่ง"
-    depth: "ลึก"
-    description: "รายละเอียด"
-    destination: "จุดหมาย"
-    destroy: "ทำลาย"
+    delivery: จัดส่ง
+    depth: ลึก
+    description: รายละเอียด
+    destination: จุดหมาย
+    destroy: ทำลาย
     details:
-    discount_amount: "จำนวนส่วนลด"
-    dismiss_banner: "ไม่ ขอบคุณ! ฉันไม่สนใจ และไม่ต้องแสดงข้อความดังกล่าวอีก"
-    display: "แสดง"
-    display_currency: "แสดงสกุลเงิน"
+    discount_amount: จำนวนส่วนลด
+    dismiss_banner: ไม่ ขอบคุณ! ฉันไม่สนใจ และไม่ต้องแสดงข้อความดังกล่าวอีก
+    display: แสดง
+    display_currency: แสดงสกุลเงิน
     doesnt_track_inventory:
-    edit: "แก้ไข"
+    edit: แก้ไข
     editing_resource:
     editing_rma_reason:
-    editing_user: "แก้ไขข้อมูลผู้ใช้"
+    editing_user: แก้ไขข้อมูลผู้ใช้
     eligibility_errors:
       messages:
         has_excluded_product:
@@ -599,391 +810,393 @@ th:
         no_user_or_email_specified:
         no_user_specified:
         not_first_order:
-    email: "อีเมล"
-    empty: "ว่างเปล่า"
-    empty_cart: "ล้างตะกร้า"
-    enable_mail_delivery: "เปิดระบบส่งเมล"
-    end: "จบ"
-    ending_in: "จบภายใน"
+    email: อีเมล
+    empty: ว่างเปล่า
+    empty_cart: ล้างตะกร้า
+    enable_mail_delivery: เปิดระบบส่งเมล
+    end: จบ
+    ending_in: จบภายใน
     environment: Environment
-    error: "ข้อผิดพลาด"
+    error: ข้อผิดพลาด
     errors:
       messages:
-        could_not_create_taxon: "ไม่สามารถสร้าง Taxon"
-        no_payment_methods_available: "ไม่พบวิธีการชำระเงินใน environment นี้"
-        no_shipping_methods_available: "ไม่พบวิธีจัดส่งสินค้าในสถานที่ดังกล่าว กรุณาเปลี่ยนที่อยู่ใหม่"
+        could_not_create_taxon: ไม่สามารถสร้าง Taxon
+        no_payment_methods_available: ไม่พบวิธีการชำระเงินใน environment นี้
+        no_shipping_methods_available: ไม่พบวิธีจัดส่งสินค้าในสถานที่ดังกล่าว กรุณาเปลี่ยนที่อยู่ใหม่
     errors_prohibited_this_record_from_being_saved:
       one: 1 ข้อผิดพลาดที่ไม่สามารถจัดเก็บข้อมูลได้
       other: "%{count} ข้อผิดพลาดที่ไม่สามารถจัดเก็บข้อมูลได้"
-    event: "กรณี"
+    event: กรณี
     events:
       spree:
         cart:
-          add: "เพิ่มลงตะกร้า"
+          add: เพิ่มลงตะกร้า
         checkout:
-          coupon_code_added: "ได้เพิ่มหมายเลขคูปองแล้ว"
+          coupon_code_added: ได้เพิ่มหมายเลขคูปองแล้ว
         content:
-          visited: "ไปยังหน้า Static content"
+          visited: ไปยังหน้า Static content
         order:
-          contents_changed: "รายการสั่งซื้อได้ทำการเปลี่ยนแปลง"
-        page_view: "ได้ดูหน้า Static page"
+          contents_changed: รายการสั่งซื้อได้ทำการเปลี่ยนแปลง
+        page_view: ได้ดูหน้า Static page
         user:
-          signup: "สมัครสมาชิก"
+          signup: สมัครสมาชิก
     exceptions:
-      count_on_hand_setter: "ไม่สามารถตั้งค่า count_on_hand ได้ด้วยตัวเอง เนื่องจากระบบได้ตั้งค่า recalculate_count_on_hand โดยอัตโนมัติ กรุณาใช้ `update_column(:count_on_hand, value)` แทน"
+      count_on_hand_setter: ไม่สามารถตั้งค่า count_on_hand ได้ด้วยตัวเอง เนื่องจากระบบได้ตั้งค่า recalculate_count_on_hand โดยอัตโนมัติ กรุณาใช้ `update_column(:count_on_hand, value)` แทน
     exchange_for:
     excl:
     existing_shipments:
     expedited_exchanges_warning:
-    expiration: "หมดอายุ"
-    extension: "ส่วนขยาย"
+    expiration: หมดอายุ
+    extension: ส่วนขยาย
     failed_payment_attempts:
-    filename: "ชื่อไฟล์"
-    fill_in_customer_info: "กรุณากรอกข้อมูลลูกค้า"
-    filter_results: "กรอกผลลัพท์"
+    filename: ชื่อไฟล์
+    fill_in_customer_info: กรุณากรอกข้อมูลลูกค้า
+    filter_results: กรอกผลลัพท์
     finalize: Finalize
     finalized:
     find_a_taxon:
-    first_item: "ราคาสินค้าชิ้นแรก"
-    first_name: "ชื่อจริง"
-    first_name_begins_with: "ชื่อจริงเริ่มต้นด้วย"
+    first_item: ราคาสินค้าชิ้นแรก
+    first_name: ชื่อจริง
+    first_name_begins_with: ชื่อจริงเริ่มต้นด้วย
     flat_percent: Flat Percent
     flat_rate_per_order: Flat Rate (ต่อรายการสั่งซื้อ)
     flexible_rate: Flexible Rate
-    forgot_password: "ลืมรหัสผ่าน"
+    forgot_password: ลืมรหัสผ่าน
     free_shipping: Free Shipping
     free_shipping_amount:
-    front_end: "หน้าขายสินค้า"
-    gateway: "ช่องทางการชำระเงิน"
+    front_end: หน้าขายสินค้า
+    gateway: ช่องทางการชำระเงิน
     gateway_config_unavailable: Gateway unavailable for environment
-    gateway_error: "เกิดข้อผิดพลาดที่ช่องทางการชำระเงิน"
-    general: "เบื้องต้น"
-    general_settings: "ข้อมูลเบื้องต้น"
+    gateway_error: เกิดข้อผิดพลาดที่ช่องทางการชำระเงิน
+    general: เบื้องต้น
+    general_settings: ข้อมูลเบื้องต้น
     google_analytics: Google Analytics
     google_analytics_id: Analytics ID
     guest_checkout: Guest Checkout
     guest_user_account: Checkout as a Guest
     has_no_shipped_units: has no shipped units
-    height: "สูง"
-    hide_cents: "ซ่อนเซ็น"
-    home: "หน้าแรก"
+    height: สูง
+    hide_cents: ซ่อนเซ็น
+    home: หน้าแรก
     i18n:
-      available_locales: "ภาษาที่รองรับ"
-      language: "ภาษา"
-      localization_settings: "ตั้งค่าภาษา"
-      this_file_language: "ภาษาไทย (TH)"
-    icon: "ไอค่อน"
+      available_locales: ภาษาที่รองรับ
+      language: ภาษา
+      localization_settings: ตั้งค่าภาษา
+      this_file_language: ภาษาไทย (TH)
+    icon: ไอค่อน
     identifier:
-    image: "รูปภาพ"
-    images: "รูปภาพ"
+    image: รูปภาพ
+    images: รูปภาพ
     implement_eligible_for_return:
     implement_requires_manual_intervention:
     inactive:
     incl:
-    included_in_price: "รวมในราคา"
-    included_price_validation: "ไม่สามารถเลือกได้หากคุณยังไม่ได้ตั้งค่าเริ่มต้นของโซนภาษี"
+    included_in_price: รวมในราคา
+    included_price_validation: ไม่สามารถเลือกได้หากคุณยังไม่ได้ตั้งค่าเริ่มต้นของโซนภาษี
     incomplete:
     info_number_of_skus_not_shown:
     info_product_has_multiple_skus:
-    instructions_to_reset_password: "กรุณากรอกอีเมลของคุณในฟอร์มด้านล่าง"
-    insufficient_stock: "สินค้าในคลังไม่เพียงพอ เรามีแค่ %{on_hand} อยู่ในขณะนี้"
+    instructions_to_reset_password: กรุณากรอกอีเมลของคุณในฟอร์มด้านล่าง
+    insufficient_stock: สินค้าในคลังไม่เพียงพอ เรามีแค่ %{on_hand} อยู่ในขณะนี้
     insufficient_stock_lines_present:
-    intercept_email_address: "ยับยั้งอีเมล"
-    intercept_email_instructions: "แก้ไขอีเมลผู้รับและแทนที่ด้วยอีเมลนี้"
+    intercept_email_address: ยับยั้งอีเมล
+    intercept_email_instructions: แก้ไขอีเมลผู้รับและแทนที่ด้วยอีเมลนี้
     internal_name:
     invalid_credit_card:
     invalid_exchange_variant:
-    invalid_payment_provider: "ผู้ให้บริการชำระเงินไม่ถูกต้อง"
-    invalid_promotion_action: "การตั้งค่าโปรโมชั่นไม่ถูกต้อง"
-    invalid_promotion_rule: "กฏของโปรโมชั่นไม่ถูกต้อง"
-    inventory: "คลัง"
-    inventory_adjustment: "ปรับแต่งคลังสินค้า"
-    inventory_error_flash_for_insufficient_quantity: "สินค้าในตะกร้าของคุณนั้นหมดเสียแล้ว"
+    invalid_payment_provider: ผู้ให้บริการชำระเงินไม่ถูกต้อง
+    invalid_promotion_action: การตั้งค่าโปรโมชั่นไม่ถูกต้อง
+    invalid_promotion_rule: กฏของโปรโมชั่นไม่ถูกต้อง
+    inventory: คลัง
+    inventory_adjustment: ปรับแต่งคลังสินค้า
+    inventory_error_flash_for_insufficient_quantity: สินค้าในตะกร้าของคุณนั้นหมดเสียแล้ว
     inventory_state:
-    is_not_available_to_shipment_address: "นั้นไม่พร้อมที่ส่งไปยังที่อยู่ดังกล่าว"
-    iso_name: "ชื่อ ISO"
-    item: "สินค้า"
-    item_description: "รายละเอียดสินค้า"
-    item_total: "จำนวนทั้งหมด"
+    is_not_available_to_shipment_address: นั้นไม่พร้อมที่ส่งไปยังที่อยู่ดังกล่าว
+    iso_name: ชื่อ ISO
+    item: สินค้า
+    item_description: รายละเอียดสินค้า
+    item_total: จำนวนทั้งหมด
     item_total_rule:
       operators:
-        gt: "มากกว่า"
-        gte: "มากกว่าหรือเท่ากับ"
+        gt: มากกว่า
+        gte: มากกว่าหรือเท่ากับ
         lt:
         lte:
-    items_cannot_be_shipped: "เราไม่สามารถส่งสินค้าดังกล่าวไปยังสถานที่ของคุณได้ กรุณาเลือกสถานที่จัดส่งอื่น"
+    items_cannot_be_shipped: เราไม่สามารถส่งสินค้าดังกล่าวไปยังสถานที่ของคุณได้ กรุณาเลือกสถานที่จัดส่งอื่น
     items_in_rmas:
     items_reimbursed:
     items_to_be_reimbursed:
     jirafe: Jirafe
     landing_page_rule:
       path: Path
-    last_name: "นามสกุล"
-    last_name_begins_with: "นามสกุลเริ่มต้นด้วย"
-    learn_more: "เพิ่มเติม"
+    last_name: นามสกุล
+    last_name_begins_with: นามสกุลเริ่มต้นด้วย
+    learn_more: เพิ่มเติม
     lifetime_stats:
     line_item_adjustments:
-    list: "รายการ"
-    loading: "กำลังโหลด"
-    locale_changed: "เปลี่ยนภาษา"
-    location: "สถานที่"
-    lock: "ล๊อก"
+    list: รายการ
+    loading: กำลังโหลด
+    locale_changed: เปลี่ยนภาษา
+    location: สถานที่
+    lock: ล๊อก
     log_entries:
-    logged_in_as: "เข้าสู่ระบบเป็น"
-    logged_in_succesfully: "เข้าสู่ระบบสำเร็จ"
-    logged_out: "คุณได้ออกจากระบบแล้ว"
-    login: "เข้าสู่ระบบ"
-    login_as_existing: "เข้าสู่ระบบจากบัญขีที่มีอยู่แล้ว"
-    login_failed: "ไม่สามารถเข้าสู่ระบบได้"
-    login_name: "เข้าสู่ระบบ"
-    logout: "ออกจากระบบ"
+    logged_in_as: เข้าสู่ระบบเป็น
+    logged_in_succesfully: เข้าสู่ระบบสำเร็จ
+    logged_out: คุณได้ออกจากระบบแล้ว
+    login: เข้าสู่ระบบ
+    login_as_existing: เข้าสู่ระบบจากบัญขีที่มีอยู่แล้ว
+    login_failed: ไม่สามารถเข้าสู่ระบบได้
+    login_name: เข้าสู่ระบบ
+    logout: ออกจากระบบ
     logs:
-    look_for_similar_items: "มองหาสินค้าที่คล้ายกัน"
-    make_refund: "ทำเรื่องขอคืนสินค้า"
+    look_for_similar_items: มองหาสินค้าที่คล้ายกัน
+    make_refund: ทำเรื่องขอคืนสินค้า
     make_sure_the_above_reimbursement_amount_is_correct:
     manage_promotion_categories:
     manage_variants:
     manual_intervention_required:
-    master_price: "ราคาหลัก"
+    master_price: ราคาหลัก
     match_choices:
-      all: "ทั้งหมด"
-      none: "ไม่มี"
-    max_items: "มากสุด"
+      all: ทั้งหมด
+      none: ไม่มี
+    max_items: มากสุด
     member_since:
     memo:
     meta_description: Meta Description
     meta_keywords: Meta Keywords
     meta_title:
     metadata: Metadata
-    minimal_amount: "จำนวนต่ำสุด"
-    month: "เดือน"
-    more: "เพิ่มเติม"
-    move_stock_between_locations: "ย้ายสินค้าข้ามสถานที่"
-    my_account: "บัญชีของท่าน"
-    my_orders: "รายการสั่งซื้อ"
-    name: "ชื่อ"
+    minimal_amount: จำนวนต่ำสุด
+    month: เดือน
+    more: เพิ่มเติม
+    move_stock_between_locations: ย้ายสินค้าข้ามสถานที่
+    my_account: บัญชีของท่าน
+    my_orders: รายการสั่งซื้อ
+    name: ชื่อ
     name_on_card:
-    name_or_sku: "ชื่อหรือ SKU (กรุณาใส่ตัวอักษรอย่างน้อย 4 ตัวขึ้นไปของชื่อสินค้า)"
-    new: "ใหม่"
+    name_or_sku: ชื่อหรือ SKU (กรุณาใส่ตัวอักษรอย่างน้อย 4 ตัวขึ้นไปของชื่อสินค้า)
+    new: ใหม่
     new_adjustment: New Adjustment
     new_country:
-    new_customer: "สมัครสมาชิก"
+    new_customer: สมัครสมาชิก
     new_customer_return:
-    new_image: "เพิ่มภาพ"
-    new_option_type: "เพิ่มรายการให้เลือก"
-    new_order: "สั่งซื้อสินค้า"
-    new_order_completed: "รายการสั่งซื้อเสร็จสิ้น"
-    new_payment: "ชำระใหม่"
-    new_payment_method: "เลือกวิธีการชำระใหม่"
-    new_product: "เพิ่มสินค้า"
-    new_promotion: "โปรโมชั่นใหม่"
+    new_image: เพิ่มภาพ
+    new_option_type: เพิ่มรายการให้เลือก
+    new_order: สั่งซื้อสินค้า
+    new_order_completed: รายการสั่งซื้อเสร็จสิ้น
+    new_payment: ชำระใหม่
+    new_payment_method: เลือกวิธีการชำระใหม่
+    new_product: เพิ่มสินค้า
+    new_promotion: โปรโมชั่นใหม่
     new_promotion_category:
-    new_property: "เพิ่มคุณลักษณะ"
-    new_prototype: "เพิ่มต้นแบบ"
+    new_property: เพิ่มคุณลักษณะ
+    new_prototype: เพิ่มต้นแบบ
     new_refund:
     new_refund_reason:
-    new_return_authorization: "รายการคืนสินค้าใหม่"
+    new_return_authorization: รายการคืนสินค้าใหม่
     new_rma_reason:
     new_shipment_at_location:
-    new_shipping_category: "เพิ่มกลุ่มวิธีการจัดส่ง"
-    new_shipping_method: "เพิ่มวิธีจัดส่ง"
-    new_state: "เพิ่มรัฐหรือจังหวัด"
-    new_stock_location: "สร้างคลังสินค้าใหม่"
-    new_stock_movement: "เพิ่มรายการเคลื่อนไหวสินค้าใหม่"
-    new_stock_transfer: "เพิ่มรายการย้ายสินค้าใหม่"
-    new_tax_category: "เพิ่มรูปแบบการคิดภาษี"
-    new_tax_rate: "เพิ่มอัตราภาษี"
+    new_shipping_category: เพิ่มกลุ่มวิธีการจัดส่ง
+    new_shipping_method: เพิ่มวิธีจัดส่ง
+    new_state: เพิ่มรัฐหรือจังหวัด
+    new_stock_location: สร้างคลังสินค้าใหม่
+    new_stock_movement: เพิ่มรายการเคลื่อนไหวสินค้าใหม่
+    new_stock_transfer: เพิ่มรายการย้ายสินค้าใหม่
+    new_tax_category: เพิ่มรูปแบบการคิดภาษี
+    new_tax_rate: เพิ่มอัตราภาษี
     new_taxon: New Taxon
-    new_taxonomy: "เพิ่ม Taxonomy"
+    new_taxonomy: เพิ่ม Taxonomy
     new_tracker: New Tracker
-    new_user: "สร้างผู้ใช้ใหม่"
-    new_variant: "เพิ่มตัวแปรใหม่"
-    new_zone: "เพิ่มเขตใหม่"
-    next: "ถัดไป"
-    no_actions_added: "ไม่พบการสั่งการ"
+    new_user: สร้างผู้ใช้ใหม่
+    new_variant: เพิ่มตัวแปรใหม่
+    new_zone: เพิ่มเขตใหม่
+    next: ถัดไป
+    no_actions_added: ไม่พบการสั่งการ
     no_payment_found:
-    no_pending_payments: "ไม่พบรายการรอชำระ"
-    no_products_found: "ไม่พบสินค้า"
+    no_pending_payments: ไม่พบรายการรอชำระ
+    no_products_found: ไม่พบสินค้า
     no_resource_found:
-    no_results: "ไม่พบผลลัพท์"
+    no_results: ไม่พบผลลัพท์
     no_returns_found:
-    no_rules_added: "ไม่พบ rules"
+    no_rules_added: ไม่พบ rules
     no_shipping_method_selected:
     no_state_changes:
-    no_tracking_present: "ไม่พบรายละเอียดของ Tracker"
-    none: "ว่าง"
+    no_tracking_present: ไม่พบรายละเอียดของ Tracker
+    none: ว่าง
     none_selected:
-    normal_amount: "ราคาปรกติ"
-    not: "ไม่"
-    not_available: "ไม่มี"
-    not_enough_stock: "จำนวนรายการสินค้าไม่พอในคลังสินค้าดังกล่าว"
+    normal_amount: ราคาปรกติ
+    not: ไม่
+    not_available: ไม่มี
+    not_enough_stock: จำนวนรายการสินค้าไม่พอในคลังสินค้าดังกล่าว
     not_found: "%{resource} นั้นไม่พบ"
     note:
     notice_messages:
-      product_cloned: "สินค้าได้ถูกทำสำเนา"
-      product_deleted: "สินค้าได้ถูกลบแล้ว"
-      product_not_cloned: "สินค้าไม่สามารถทำสำเนาได้"
-      product_not_deleted: "สินค้าไม่สามารถถูกลบได้"
+      product_cloned: สินค้าได้ถูกทำสำเนา
+      product_deleted: สินค้าได้ถูกลบแล้ว
+      product_not_cloned: สินค้าไม่สามารถทำสำเนาได้
+      product_not_deleted: สินค้าไม่สามารถถูกลบได้
       variant_deleted: Variant has been deleted
-      variant_not_deleted: "ตัวแปรไม่สามารถถูกลบได้"
+      variant_not_deleted: ตัวแปรไม่สามารถถูกลบได้
     num_orders:
-    on_hand: "สินค้าในคลัง"
-    open: "เปิด"
-    open_all_adjustments: "เปิดรายการปรับปรุงทั้งหมด"
-    option_type: "ประเภทตัวเลือก"
-    option_type_placeholder: "เลือกประเภทตัวเลือก"
-    option_types: "ประเภทตัวเลือก"
-    option_value: "ค่าของตัวเลือก"
-    option_values: "ค่าของตัวเลือก"
-    optional: "ตัวเลือก"
-    options: "ตัวเลือก"
-    or: "หรือ"
+    on_hand: สินค้าในคลัง
+    open: เปิด
+    open_all_adjustments: เปิดรายการปรับปรุงทั้งหมด
+    option_type: ประเภทตัวเลือก
+    option_type_placeholder: เลือกประเภทตัวเลือก
+    option_types: ประเภทตัวเลือก
+    option_value: ค่าของตัวเลือก
+    option_values: ค่าของตัวเลือก
+    optional: ตัวเลือก
+    options: ตัวเลือก
+    or: หรือ
     or_over_price: "%{price} หรือมากกว่า"
-    order: "รายการ"
+    order: รายการ
     order_adjustments: Order adjustments
     order_already_updated:
     order_approved:
     order_canceled:
-    order_details: "รายละเอียดการสั่งซื้อ"
-    order_email_resent: "ส่งอีเมลการสั่งซื้อใหม่"
-    order_information: "ข้อมูลการสั่งซื้อ"
+    order_details: รายละเอียดการสั่งซื้อ
+    order_email_resent: ส่งอีเมลการสั่งซื้อใหม่
+    order_information: ข้อมูลการสั่งซื้อ
     order_mailer:
       cancel_email:
-        dear_customer: "ถึงคุณลูกค้า,\\n"
-        instructions: "สินค้าของคุณได้ถูกยกเลิกแล้ว กรุณาเก็บหลักฐานอีเมลฉบับนี้เอาไว้ เพื่อใช้ในการอ้างอิงในอนาคต"
-        order_summary_canceled: "รายการที่สั่งซื้อ [ยกเลิก]"
-        subject: "การยกเลิกการสั่งซื้อ"
+        dear_customer: ถึงคุณลูกค้า,\n
+        instructions: สินค้าของคุณได้ถูกยกเลิกแล้ว กรุณาเก็บหลักฐานอีเมลฉบับนี้เอาไว้ เพื่อใช้ในการอ้างอิงในอนาคต
+        order_summary_canceled: รายการที่สั่งซื้อ [ยกเลิก]
+        subject: การยกเลิกการสั่งซื้อ
         subtotal:
         total:
       confirm_email:
-        dear_customer: "ถึงคุณลูกค้า,\\n"
-        instructions: "กรุณาตรวจสอบและเก็บรายละเอียดการสั่งซื้อนี้เอาไว้"
-        order_summary: "รายการที่สั่งซื้อ"
-        subject: "ยืนยันการสั่งซื้อ"
+        dear_customer: ถึงคุณลูกค้า,\n
+        instructions: กรุณาตรวจสอบและเก็บรายละเอียดการสั่งซื้อนี้เอาไว้
+        order_summary: รายการที่สั่งซื้อ
+        subject: ยืนยันการสั่งซื้อ
         subtotal:
-        thanks: "ขอขอบคุณที่ได้รับใช้คุณ"
+        thanks: ขอขอบคุณที่ได้รับใช้คุณ
         total:
-    order_not_found: "เราไม่พบรายการสั่งซื้อของคุณ กรุณาลองใหม่อีกครั้ง"
-    order_number: "รหัสสั่งซื้อ %{number}"
-    order_processed_successfully: "รายการสั่งซื้อของคุณถูกดำเนินการเรียบร้อยแล้ว"
+      inventory_cancellation:
+        dear_customer: ถึงคุณลูกค้า,\n
+    order_not_found: เราไม่พบรายการสั่งซื้อของคุณ กรุณาลองใหม่อีกครั้ง
+    order_number: รหัสสั่งซื้อ %{number}
+    order_processed_successfully: รายการสั่งซื้อของคุณถูกดำเนินการเรียบร้อยแล้ว
     order_resumed:
     order_state:
-      address: "ที่อยู่"
-      awaiting_return: "อยู่ในระหว่างการคืน"
-      canceled: "ยกเลิก"
-      cart: "ตะกร้า"
-      complete: "เสร็จสิ้น"
-      confirm: "ยืนยัน"
+      address: ที่อยู่
+      awaiting_return: อยู่ในระหว่างการคืน
+      canceled: ยกเลิก
+      cart: ตะกร้า
+      complete: เสร็จสิ้น
+      confirm: ยืนยัน
       considered_risky:
-      delivery: "ส่งสินค้า"
-      payment: "ชำระเงิน"
-      resumed: "ต่อไป"
-      returned: "คืน"
-    order_summary: "รายการที่สั่งซื้อ"
-    order_sure_want_to: "คุณยืนยันว่าต้องการ %{event} กับรายการสั่งซื้อนี้?"
-    order_total: "ราคารวม"
-    order_updated: "รายการสั่งซื้อได้ถูกปรับปรุงแล้ว"
-    orders: "รายการสั่งซื้อ"
+      delivery: ส่งสินค้า
+      payment: ชำระเงิน
+      resumed: ต่อไป
+      returned: คืน
+    order_summary: รายการที่สั่งซื้อ
+    order_sure_want_to: คุณยืนยันว่าต้องการ %{event} กับรายการสั่งซื้อนี้?
+    order_total: ราคารวม
+    order_updated: รายการสั่งซื้อได้ถูกปรับปรุงแล้ว
+    orders: รายการสั่งซื้อ
     other_items_in_other:
-    out_of_stock: "สินค้าหมด"
-    overview: "ภาพรวม"
-    package_from: "สินค้าจาก"
+    out_of_stock: สินค้าหมด
+    overview: ภาพรวม
+    package_from: สินค้าจาก
     pagination:
-      next_page: "หน้าต่อไป »"
+      next_page: หน้าต่อไป »
       previous_page: "« ก่อนก่อนนี้"
       truncate: "…"
-    password: "รหัสผ่าน"
-    paste: "แปะ"
+    password: รหัสผ่าน
+    paste: แปะ
     path: Path
-    pay: "ชำระ"
-    payment: "ชำระ"
+    pay: ชำระ
+    payment: ชำระ
     payment_could_not_be_created:
     payment_identifier:
-    payment_information: "ข้อมูลการชำระเงิน"
-    payment_method: "วิธีชำระเงิน"
+    payment_information: ข้อมูลการชำระเงิน
+    payment_method: วิธีชำระเงิน
     payment_method_not_supported:
-    payment_methods: "วิธีชำระเงิน"
-    payment_processing_failed: "ไม่สามารถชำระเงินได้ กรุณาตรวจสอบข้อมูลที่คุณได้กรอกใหม่"
-    payment_processor_choose_banner_text: "หากคุณต้องการความช่วยเหลือในการตัดเงิน กรุณาไปยัง"
-    payment_processor_choose_link: "หน้าชำระเงิน"
-    payment_state: "สถานะการชำระเงิน"
+    payment_methods: วิธีชำระเงิน
+    payment_processing_failed: ไม่สามารถชำระเงินได้ กรุณาตรวจสอบข้อมูลที่คุณได้กรอกใหม่
+    payment_processor_choose_banner_text: หากคุณต้องการความช่วยเหลือในการตัดเงิน กรุณาไปยัง
+    payment_processor_choose_link: หน้าชำระเงิน
+    payment_state: สถานะการชำระเงิน
     payment_states:
-      balance_due: "จำนวนที่ค้าง"
+      balance_due: จำนวนที่ค้าง
       checkout: checkout
-      completed: "เสร็จสิ้น"
+      completed: เสร็จสิ้น
       credit_owed: credit owed
-      failed: "ผิดพลาด"
-      paid: "ชำระแล้ว"
-      pending: "รอ"
-      processing: "กำลังดำเนินการ"
+      failed: ผิดพลาด
+      paid: ชำระแล้ว
+      pending: รอ
+      processing: กำลังดำเนินการ
       void: void
-    payment_updated: "ได้ปรับปรุงการชำระเงินแล้ว"
-    payments: "รายการชำระเงิน"
+    payment_updated: ได้ปรับปรุงการชำระเงินแล้ว
+    payments: รายการชำระเงิน
     pending:
-    percent: "เปอร์เซ็น"
-    percent_per_item: "เปอร์เซ็นต่อชิ้น"
+    percent: เปอร์เซ็น
+    percent_per_item: เปอร์เซ็นต่อชิ้น
     permalink: Permalink
-    phone: "เบอร์โทรศัพท์"
-    place_order: "สั่งซื้อ"
-    please_define_payment_methods: "กรุณาเลือกวิธีการชำระก่อน"
-    populate_get_error: "เกิดข้อผิดพลาด กรุณาเพิ่มสินค้าใหม่อีกครั้ง"
-    powered_by: "สนับสนุนโดย"
+    phone: เบอร์โทรศัพท์
+    place_order: สั่งซื้อ
+    please_define_payment_methods: กรุณาเลือกวิธีการชำระก่อน
+    populate_get_error: เกิดข้อผิดพลาด กรุณาเพิ่มสินค้าใหม่อีกครั้ง
+    powered_by: สนับสนุนโดย
     pre_tax_amount:
     pre_tax_refund_amount:
     pre_tax_total:
     preferred_reimbursement_type:
-    presentation: "แสดง"
-    previous: "ก่อนหน้า"
+    presentation: แสดง
+    previous: ก่อนหน้า
     previous_state_missing:
-    price: "ราคา"
-    price_range: "ราคาระหว่าง"
+    price: ราคา
+    price_range: ราคาระหว่าง
     price_sack: Price Sack
     process: Process
-    product: "สินค้า"
-    product_details: "รายละเอียดสินค้า"
-    product_has_no_description: "สินค้าไม่มีรายละเอียด"
-    product_not_available_in_this_currency: "สินค้านี้ไม่รองรับสกุลเงินนี้"
-    product_properties: "สรรพคุณของสินค้า"
+    product: สินค้า
+    product_details: รายละเอียดสินค้า
+    product_has_no_description: สินค้าไม่มีรายละเอียด
+    product_not_available_in_this_currency: สินค้านี้ไม่รองรับสกุลเงินนี้
+    product_properties: สรรพคุณของสินค้า
     product_rule:
-      choose_products: "เลือกสินค้า"
+      choose_products: เลือกสินค้า
       label:
-      match_all: "ทั้งหมด"
-      match_any: "อย่างน้อยหนึ่ง"
+      match_all: ทั้งหมด
+      match_any: อย่างน้อยหนึ่ง
       match_none:
       product_source:
-        group: "จากกลุ่มของสินค้า"
-        manual: "เลือกเอง"
-    products: "สินค้า"
-    promotion: "โปรโมชั่น"
-    promotion_action: "ดำเนินการโปรโมชั่น"
+        group: จากกลุ่มของสินค้า
+        manual: เลือกเอง
+    products: สินค้า
+    promotion: โปรโมชั่น
+    promotion_action: ดำเนินการโปรโมชั่น
     promotion_action_types:
       create_adjustment:
         description: Creates a promotion credit adjustment on the order
-        name: "สร้างการปรับเปลี่ยน"
+        name: สร้างการปรับเปลี่ยน
       create_item_adjustments:
         description:
         name:
       create_line_items:
-        description: "สร้างตะกร้าสินค้าด้วยจำนวนที่กำหนดจากตัวแปร"
-        name: "สร้าง line items"
+        description: สร้างตะกร้าสินค้าด้วยจำนวนที่กำหนดจากตัวแปร
+        name: สร้าง line items
       free_shipping:
         description:
         name:
-    promotion_actions: "ดำเนินการ"
+    promotion_actions: ดำเนินการ
     promotion_form:
       match_policies:
-        all: "จับคู่ทั้งหมด"
-        any: "จับคู่อย่างใดอย่างหนึ่ง"
-    promotion_rule: "กฏของโปรโมชั่น"
+        all: จับคู่ทั้งหมด
+        any: จับคู่อย่างใดอย่างหนึ่ง
+    promotion_rule: กฏของโปรโมชั่น
     promotion_rule_types:
       first_order:
-        description: "ต้องเป็นรายการสั่งซื้อแรกเท่านั้น"
-        name: "รายการแรก"
+        description: ต้องเป็นรายการสั่งซื้อแรกเท่านั้น
+        name: รายการแรก
       item_total:
-        description: "จำนวนสั่งซื้อนั้นอยู่ในเกณฑ์ดังกล่าว"
-        name: "จำนวนทั้งหมด"
+        description: จำนวนสั่งซื้อนั้นอยู่ในเกณฑ์ดังกล่าว
+        name: จำนวนทั้งหมด
       landing_page:
-        description: "ลูกค้าต้องไปยังหน้าที่กำหนด"
+        description: ลูกค้าต้องไปยังหน้าที่กำหนด
         name: Landing Page
       one_use_per_user:
         description:
@@ -992,46 +1205,46 @@ th:
         description:
         name:
       product:
-        description: "รายการนั้นรวมสินค้าที่กำหนด"
-        name: "สินค้า"
+        description: รายการนั้นรวมสินค้าที่กำหนด
+        name: สินค้า
       taxon:
         description:
         name:
       user:
-        description: "เฉพาะลูกค้าที่กำหนด"
-        name: "ผู้ใช้"
+        description: เฉพาะลูกค้าที่กำหนด
+        name: ผู้ใช้
       user_logged_in:
-        description: "เฉพาะลูกค้าที่เข้าระบบ"
-        name: "ผู้ใช้ในระบบ"
+        description: เฉพาะลูกค้าที่เข้าระบบ
+        name: ผู้ใช้ในระบบ
     promotion_uses:
     promotionable:
-    promotions: "โปรโมชั่น"
+    promotions: โปรโมชั่น
     propagate_all_variants:
-    properties: "คุณสมบัติ"
-    property: "คุณสมบัติ"
+    properties: คุณสมบัติ
+    property: คุณสมบัติ
     prototype: Prototype
     prototypes: Prototypes
-    provider: "ผู้ให้บริการ"
-    provider_settings_warning: "หากคุณต้องการเปลี่ยนประเภทผู้ให้บริการ คุณจำเป็นต้องบันทึกรายการก่อนจึงจะสามารถแก้ไขค่าของผู้ให้บริการได้"
-    qty: "จำนวน"
-    quantity: "จำนวน"
-    quantity_returned: "จำนวนที่คืน"
-    quantity_shipped: "จำนวนที่ส่ง"
+    provider: ผู้ให้บริการ
+    provider_settings_warning: หากคุณต้องการเปลี่ยนประเภทผู้ให้บริการ คุณจำเป็นต้องบันทึกรายการก่อนจึงจะสามารถแก้ไขค่าของผู้ให้บริการได้
+    qty: จำนวน
+    quantity: จำนวน
+    quantity_returned: จำนวนที่คืน
+    quantity_shipped: จำนวนที่ส่ง
     quick_search:
-    rate: "อัตรา"
-    reason: "เหตุผล"
-    receive: "ได้รับ"
-    receive_stock: "ได้รับสินค้า"
-    received: "ได้รับแล้ว"
+    rate: อัตรา
+    reason: เหตุผล
+    receive: ได้รับ
+    receive_stock: ได้รับสินค้า
+    received: ได้รับแล้ว
     reception_status:
-    reference: "อ้างอิง"
-    refund: "คืนเงิน"
+    reference: อ้างอิง
+    refund: คืนเงิน
     refund_amount_must_be_greater_than_zero:
     refund_reasons:
     refunded_amount:
     refunds:
-    register: "ลงทะเบียน"
-    registration: "ลงทะเบียน"
+    register: ลงทะเบียน
+    registration: ลงทะเบียน
     reimburse:
     reimbursed:
     reimbursement:
@@ -1053,21 +1266,21 @@ th:
     reimbursements:
     reject:
     rejected:
-    remember_me: "จำฉัน"
-    remove: "ลบ"
-    rename: "เปลี่ยนชื่อ"
+    remember_me: จำฉัน
+    remove: ลบ
+    rename: เปลี่ยนชื่อ
     report:
-    reports: "รายงาน"
-    resend: "ส่งใหม่"
-    reset_password: "ตั้งรหัสผ่านใหม่"
-    response_code: "รหัสที่ได้รับ"
-    resume: "ทำต่อ"
-    resumed: "ทำต่อ"
-    return: "กลับ"
-    return_authorization: "รายการคืนสินค้า"
+    reports: รายงาน
+    resend: ส่งใหม่
+    reset_password: ตั้งรหัสผ่านใหม่
+    response_code: รหัสที่ได้รับ
+    resume: ทำต่อ
+    resumed: ทำต่อ
+    return: กลับ
+    return_authorization: รายการคืนสินค้า
     return_authorization_reasons:
-    return_authorization_updated: "รายการคืนสินค้าได้ปรับปรุงแล้ว"
-    return_authorizations: "รายการคืนสินค้า"
+    return_authorization_updated: รายการคืนสินค้าได้ปรับปรุงแล้ว
+    return_authorizations: รายการคืนสินค้า
     return_item_inventory_unit_ineligible:
     return_item_inventory_unit_reimbursed:
     return_item_rma_ineligible:
@@ -1075,101 +1288,101 @@ th:
     return_items:
     return_items_cannot_be_associated_with_multiple_orders:
     return_number:
-    return_quantity: "จำนวนที่คืน"
-    returned: "คืน"
+    return_quantity: จำนวนที่คืน
+    returned: คืน
     returns:
-    review: "ตรวจสอบ"
+    review: ตรวจสอบ
     risk:
     risk_analysis:
     risky:
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
-    roles: "หน้าที่"
-    rules: "กฏ"
+    roles: หน้าที่
+    rules: กฏ
     safe:
-    sales_total: "ยอดขายรวม"
-    sales_total_description: "ยอดขายรวมสำหรับรายการที่สั่งซื้อทั้งหมด"
-    sales_totals: "ยอดขายรวม"
-    save_and_continue: "บันทึกและดำเนินการต่อ"
+    sales_total: ยอดขายรวม
+    sales_total_description: ยอดขายรวมสำหรับรายการที่สั่งซื้อทั้งหมด
+    sales_totals: ยอดขายรวม
+    save_and_continue: บันทึกและดำเนินการต่อ
     save_my_address:
-    say_no: "ไม่"
-    say_yes: "ถูกต้อง"
+    say_no: ไม่
+    say_yes: ถูกต้อง
     scope: Scope
-    search: "ค้นหา"
-    search_results: "ผลลัพท์การค้นหาของ '%{keywords}'"
-    searching: "กำลังค้นหา"
+    search: ค้นหา
+    search_results: ผลลัพท์การค้นหาของ '%{keywords}'
+    searching: กำลังค้นหา
     secure_connection_type: Secure Connection Type
-    security_settings: "ตั้งค่าความปลอดภัย"
-    select: "เลือก"
+    security_settings: ตั้งค่าความปลอดภัย
+    select: เลือก
     select_a_return_authorization_reason:
     select_a_stock_location:
-    select_from_prototype: "เลือกจาก Prototype"
-    select_stock: "เลือกจากคลัง"
-    send_copy_of_all_mails_to: "ส่งสำเนาไปยัง"
-    send_mails_as: "ส่งเมลด้วย"
-    server: "เซิร์ฟเวอร์"
-    server_error: "เซิร์ฟเวอร์ส่งข้อผิดพลาด"
-    settings: "ตั้งค่า"
-    ship: "ส่ง"
-    ship_address: "ที่อยู่���่งของ"
-    ship_total: "ค่าจัดส่ง"
-    shipment: "การส่ง"
+    select_from_prototype: เลือกจาก Prototype
+    select_stock: เลือกจากคลัง
+    send_copy_of_all_mails_to: ส่งสำเนาไปยัง
+    send_mails_as: ส่งเมลด้วย
+    server: เซิร์ฟเวอร์
+    server_error: เซิร์ฟเวอร์ส่งข้อผิดพลาด
+    settings: ตั้งค่า
+    ship: ส่ง
+    ship_address: ที่อยู่���่งของ
+    ship_total: ค่าจัดส่ง
+    shipment: การส่ง
     shipment_adjustments:
     shipment_details:
     shipment_mailer:
       shipped_email:
-        dear_customer: "ถึงคุณลูกค้า,\\n"
-        instructions: "รายการสั่งซื้อของคุณได้ทำการจัดส่งแล้ว"
-        shipment_summary: "สรุปรายการส่งสินค้า"
-        subject: "การแจ้งเตือนการส่งสินค้า"
-        thanks: "ขอขอบพระคุณสำหรับการสั่งซื้อกับเรา"
-        track_information: "หมายเลขการติดตามสถานะการส่งสินค้า: %{tracking}"
-        track_link: "ลิ้งไปยังหน้าสถานะ: %{url}"
-    shipment_state: "สถานะการจัดส่ง"
+        dear_customer: ถึงคุณลูกค้า,\n
+        instructions: รายการสั่งซื้อของคุณได้ทำการจัดส่งแล้ว
+        shipment_summary: สรุปรายการส่งสินค้า
+        subject: การแจ้งเตือนการส่งสินค้า
+        thanks: ขอขอบพระคุณสำหรับการสั่งซื้อกับเรา
+        track_information: 'หมายเลขการติดตามสถานะการส่งสินค้า: %{tracking}'
+        track_link: 'ลิ้งไปยังหน้าสถานะ: %{url}'
+    shipment_state: สถานะการจัดส่ง
     shipment_states:
-      backorder: "พร้อมจัดส่ง"
+      backorder: พร้อมจัดส่ง
       canceled:
-      partial: "บางส่วน"
-      pending: "รอ"
-      ready: "พร้อม"
-      shipped: "ส่งแล้ว"
+      partial: บางส่วน
+      pending: รอ
+      ready: พร้อม
+      shipped: ส่งแล้ว
     shipment_transfer_error:
     shipment_transfer_success:
-    shipments: "การจัดส่ง"
-    shipped: "ส่งแล้ว"
-    shipping: "ส่ง"
-    shipping_address: "ที่อยู่การจัดส่ง"
-    shipping_categories: "ประเภทการจัดส่ง"
-    shipping_category: "ประเภทการจัดส่ง"
-    shipping_flat_rate_per_item: "อัตราสุทธิต่อชิ้น"
-    shipping_flat_rate_per_order: "อัตราสุทธิ"
-    shipping_flexible_rate: "อัตราแปรผั่นต่อชิ้น"
-    shipping_instructions: "ขั้นตอนการจัดส่ง"
-    shipping_method: "วิธีการจัดส่ง"
-    shipping_methods: "วิธีการจัดส่ง"
+    shipments: การจัดส่ง
+    shipped: ส่งแล้ว
+    shipping: ส่ง
+    shipping_address: ที่อยู่การจัดส่ง
+    shipping_categories: ประเภทการจัดส่ง
+    shipping_category: ประเภทการจัดส่ง
+    shipping_flat_rate_per_item: อัตราสุทธิต่อชิ้น
+    shipping_flat_rate_per_order: อัตราสุทธิ
+    shipping_flexible_rate: อัตราแปรผั่นต่อชิ้น
+    shipping_instructions: ขั้นตอนการจัดส่ง
+    shipping_method: วิธีการจัดส่ง
+    shipping_methods: วิธีการจัดส่ง
     shipping_price_sack: Price sack
     shipping_total:
-    shop_by_taxonomy: "ซื้อโดย %{taxonomy}"
-    shopping_cart: "ตะกร้าสินค้า"
-    show: "แสดง"
-    show_active: "แสดงที่ใช้งานอยู่"
-    show_deleted: "แสดงที่ลบ"
-    show_only_complete_orders: "แสดงรายการสั่งซื้อที่สมบูรณ์"
+    shop_by_taxonomy: ซื้อโดย %{taxonomy}
+    shopping_cart: ตะกร้าสินค้า
+    show: แสดง
+    show_active: แสดงที่ใช้งานอยู่
+    show_deleted: แสดงที่ลบ
+    show_only_complete_orders: แสดงรายการสั่งซื้อที่สมบูรณ์
     show_only_considered_risky:
-    show_rate_in_label: "แสดงอัตรา"
+    show_rate_in_label: แสดงอัตรา
     sku:
     skus:
     slug:
-    source: "จาก"
-    special_instructions: "วิธี"
-    split: "แยก"
-    spree_gateway_error_flash_for_checkout: "เกิดปัญหาขึ้นกับข้อมูลการชำระเงินของคุณ กรุณาตรวจสอบข้อมูลการชำระเงินของคุณแล้วลองใหม่"
+    source: จาก
+    special_instructions: วิธี
+    split: แยก
+    spree_gateway_error_flash_for_checkout: เกิดปัญหาขึ้นกับข้อมูลการชำระเงินของคุณ กรุณาตรวจสอบข้อมูลการชำระเงินของคุณแล้วลองใหม่
     ssl:
       change_protocol:
-    start: "เริ่ม"
-    state: "จังหวัด"
-    state_based: "จังหวัดที่ตั้ง"
+    start: เริ่ม
+    state: จังหวัด
+    state_based: จังหวัดที่ตั้ง
     state_machine_states:
       accepted:
       address:
@@ -1202,44 +1415,44 @@ th:
       returned:
       shipped:
       void:
-    states: "จังหวัด"
-    states_required: "จังหวัดที่ต้องการ"
-    status: "สถานะ"
+    states: จังหวัด
+    states_required: จังหวัดที่ต้องการ
+    status: สถานะ
     stock:
-    stock_location: "สถานที่ของคลังสินค้า"
-    stock_location_info: "ข้อมูลของคลังสินค้า"
-    stock_locations: "สถานที่ของคลังสินค้า"
+    stock_location: สถานที่ของคลังสินค้า
+    stock_location_info: ข้อมูลของคลังสินค้า
+    stock_locations: สถานที่ของคลังสินค้า
     stock_locations_need_a_default_country:
-    stock_management: "การจัดการคลังสินค้า"
-    stock_management_requires_a_stock_location: "กรุณาสร้างคลังสินค้าเพื่อที่จะสามารถบริหารคลังได้"
-    stock_movements: "สินค้าเคลื่อนไหว"
-    stock_movements_for_stock_location: "สินค้าเคลื่อนไหวของ %{stock_location_name}"
-    stock_successfully_transferred: "สินค้าได้ย้ายไปยังคลังที่ต้องการแล้ว"
-    stock_transfer: "ย้ายสินค้า"
-    stock_transfers: "ย้ายสินค้า"
-    stop: "หยุด"
+    stock_management: การจัดการคลังสินค้า
+    stock_management_requires_a_stock_location: กรุณาสร้างคลังสินค้าเพื่อที่จะสามารถบริหารคลังได้
+    stock_movements: สินค้าเคลื่อนไหว
+    stock_movements_for_stock_location: สินค้าเคลื่อนไหวของ %{stock_location_name}
+    stock_successfully_transferred: สินค้าได้ย้ายไปยังคลังที่ต้องการแล้ว
+    stock_transfer: ย้ายสินค้า
+    stock_transfers: ย้ายสินค้า
+    stop: หยุด
     store: Store
-    street_address: "ที่อยู่"
-    street_address_2: "ที่อยู่ (ต่อ)"
-    subtotal: "ยอด"
-    subtract: "หักออก"
+    street_address: ที่อยู่
+    street_address_2: ที่อยู่ (ต่อ)
+    subtotal: ยอด
+    subtract: หักออก
     success:
     successfully_created: "%{resource} นั้นได้สร้างเรียบร้อยแล้ว"
     successfully_refunded:
     successfully_removed: "%{resource} นั้นได้ถูกลบเรียบร้อยแล้ว"
-    successfully_signed_up_for_analytics: "ได้สมัคร Spree Analytics เป็นที่เรียบร้อย"
+    successfully_signed_up_for_analytics: ได้สมัคร Spree Analytics เป็นที่เรียบร้อย
     successfully_updated: "%{resource} นั้นได้ปรับปรุงเรียบร้อยแล้ว"
     summary:
-    tax: "ภาษี"
-    tax_categories: "ประเภทภาษี"
-    tax_category: "ประเภทภาษี"
+    tax: ภาษี
+    tax_categories: ประเภทภาษี
+    tax_category: ประเภทภาษี
     tax_code:
     tax_included:
-    tax_rate_amount_explanation: "อัตราภาษีนั้นเป็นทศนิยมเพื่อง่ายในการคำนวน (ตัวอย่าง, หากภาษีคือ 7% ให้ใส่ 0.07)"
-    tax_rates: "อัตราภาษี"
+    tax_rate_amount_explanation: อัตราภาษีนั้นเป็นทศนิยมเพื่อง่ายในการคำนวน (ตัวอย่าง, หากภาษีคือ 7% ให้ใส่ 0.07)
+    tax_rates: อัตราภาษี
     taxon: Taxon
-    taxon_edit: "แก้ไข Taxon"
-    taxon_placeholder: "เพิ่ม Taxon"
+    taxon_edit: แก้ไข Taxon
+    taxon_placeholder: เพิ่ม Taxon
     taxon_rule:
       choose_taxons:
       label:
@@ -1247,28 +1460,28 @@ th:
       match_any:
     taxonomies: Taxonomies
     taxonomy: Taxonomy
-    taxonomy_edit: "แก้ไข taxonomy"
-    taxonomy_tree_error: "รายการที่ขอเปลี่ยนแปลงไม่สามารถทำได้ และได้ทำการแก้ไขคืนดังเดิม โปรดลองอีกครั้ง"
+    taxonomy_edit: แก้ไข taxonomy
+    taxonomy_tree_error: รายการที่ขอเปลี่ยนแปลงไม่สามารถทำได้ และได้ทำการแก้ไขคืนดังเดิม โปรดลองอีกครั้ง
     taxonomy_tree_instruction: "* คลิกขวาที่ Child ใน Tree เพื่อเข้าเมนูในการเพิ่ม, ลบ หรือจัดรายการ Child"
     taxons: Taxons
-    test: "ทดสอบ"
+    test: ทดสอบ
     test_mailer:
       test_email:
-        greeting: "ยินดีด้วย!"
-        message: "หากคุณได้รับอีเมลฉบับนี้ แสดงว่าการตั้งค่าอีเมลของคุณนั้นถูกต้อง"
-        subject: "ทดสอบอีเมล"
-    test_mode: "โหมดทดสอบ"
-    thank_you_for_your_order: "ขอบคุณสำหรับการสั่งซื้อของคุณ กรุณาเก็บหน้านี้เอาไว้"
-    there_are_no_items_for_this_order: "ไม่พบรายการสินค้าในการสั่งซื้อนี้ กรุณาเพิ่มรายการสินค้าเพื่อทำการต่อ"
-    there_were_problems_with_the_following_fields: "เกิดปัญหากับ Field ดังกล่าว"
+        greeting: ยินดีด้วย!
+        message: หากคุณได้รับอีเมลฉบับนี้ แสดงว่าการตั้งค่าอีเมลของคุณนั้นถูกต้อง
+        subject: ทดสอบอีเมล
+    test_mode: โหมดทดสอบ
+    thank_you_for_your_order: ขอบคุณสำหรับการสั่งซื้อของคุณ กรุณาเก็บหน้านี้เอาไว้
+    there_are_no_items_for_this_order: ไม่พบรายการสินค้าในการสั่งซื้อนี้ กรุณาเพิ่มรายการสินค้าเพื่อทำการต่อ
+    there_were_problems_with_the_following_fields: เกิดปัญหากับ Field ดังกล่าว
     this_order_has_already_received_a_refund:
-    thumbnail: "รูป Thumnail"
+    thumbnail: รูป Thumnail
     tiered_flat_rate:
     tiered_percent:
     tiers:
-    time: "เวลา"
-    to_add_variants_you_must_first_define: "หากเพิ่มตัวแปร คุณต้องกำหนด"
-    total: "จำนวน"
+    time: เวลา
+    to_add_variants_you_must_first_define: หากเพิ่มตัวแปร คุณต้องกำหนด
+    total: จำนวน
     total_per_item:
     total_pre_tax_refund:
     total_price:
@@ -1277,54 +1490,78 @@ th:
     tracking: Tracking
     tracking_number: Tracking Number
     tracking_url: Tracking URL
-    tracking_url_placeholder: "ตัวอย่าง http://quickship.com/package?num=:tracking"
+    tracking_url_placeholder: ตัวอย่าง http://quickship.com/package?num=:tracking
     transaction_id:
-    transfer_from_location: "ย้ายจาก"
-    transfer_stock: "ย้ายสินค้า"
-    transfer_to_location: "ย้ายไป"
+    transfer_from_location: ย้ายจาก
+    transfer_stock: ย้ายสินค้า
+    transfer_to_location: ย้ายไป
     tree: Tree
-    type: "ประเภท"
-    type_to_search: "พิมพ์เพื่อค้นหา"
-    unable_to_connect_to_gateway: "ไม่สามารถติดต่อกับ Gateway"
+    type: ประเภท
+    type_to_search: พิมพ์เพื่อค้นหา
+    unable_to_connect_to_gateway: ไม่สามารถติดต่อกับ Gateway
     unable_to_create_reimbursements:
-    under_price: "ไม่เกิน %{price}"
-    unlock: "ปลดล๊อก"
-    unrecognized_card_type: "ไม่รู้จักบัตรประเภทนี้"
-    unshippable_items: "สินค้าที่ไม่สามารถส่งได้"
-    update: "แก้ไข"
-    updating: "กำลังแก้ไข"
-    usage_limit: "ลิมิตการใช้"
+    under_price: ไม่เกิน %{price}
+    unlock: ปลดล๊อก
+    unrecognized_card_type: ไม่รู้จักบัตรประเภทนี้
+    unshippable_items: สินค้าที่ไม่สามารถส่งได้
+    update: แก้ไข
+    updating: กำลังแก้ไข
+    usage_limit: ลิมิตการใช้
     use_app_default:
-    use_billing_address: "ใช้ที่อยู่ที่ออกใบเสร็จ"
-    use_new_cc: "ใช้บัตรใบใหม่"
-    use_s3: "ใช้ Amazon S3 สำหรับรูปภาพ"
-    user: "ผู้ใช้"
+    use_billing_address: ใช้ที่อยู่ที่ออกใบเสร็จ
+    use_new_cc: ใช้บัตรใบใหม่
+    use_s3: ใช้ Amazon S3 สำหรับรูปภาพ
+    user: ผู้ใช้
     user_rule:
-      choose_users: "เลือกผู้ใช้"
-    users: "ผู้ใช้"
+      choose_users: เลือกผู้ใช้
+    users: ผู้ใช้
     validation:
-      cannot_be_less_than_shipped_units: "ไม่สามารถน้อยกว่าจำนวนในการจัดส่ง"
+      cannot_be_less_than_shipped_units: ไม่สามารถน้อยกว่าจำนวนในการจัดส่ง
       cannot_destroy_line_item_as_inventory_units_have_shipped:
       exceeds_available_stock: exceeds available stock. Please ensure line items have a valid quantity.
-      is_too_large: "นั้นใหญ่เกินไป -- สินค้าในมือไม่สามารถรองรับจำนวนที่ต้องการได้"
-      must_be_int: "ต้องเป็นเลขจำนวนเต็ม"
-      must_be_non_negative: "ต้องเป็นค่าที่ไม่ติดลบ"
+      is_too_large: นั้นใหญ่เกินไป -- สินค้าในมือไม่สามารถรองรับจำนวนที่ต้องการได้
+      must_be_int: ต้องเป็นเลขจำนวนเต็ม
+      must_be_non_negative: ต้องเป็นค่าที่ไม่ติดลบ
       unpaid_amount_not_zero:
-    value: "ค่า"
-    variant: "ตัวแปร"
-    variant_placeholder: "เลือกตัวแปร"
-    variants: "ตัวแปร"
-    version: "เวอร์ชั่น"
+    value: ค่า
+    variant: ตัวแปร
+    variant_placeholder: เลือกตัวแปร
+    variants: ตัวแปร
+    version: เวอร์ชั่น
     void: Void
-    weight: "น้ำหนัก"
-    what_is_a_cvv: "อะไรคือ (CVV) บนบัตรเครดิต?"
-    what_is_this: "นี่คืออะไร"
-    width: "กว้าง"
-    year: "ปี"
-    you_have_no_orders_yet: "คุณยังไม่มีรายการสั่งซื้อ"
-    your_cart_is_empty: "ตะกร้าคุณว่างเปล่า"
-    your_order_is_empty_add_product: "คุณไม่มีรายการสั่งซื้อ กรุณาค้นหาและเพิ่มสินค้าด้านบน"
-    zip: "รหัสไปรษณีย์"
-    zipcode: "รหัสไปรษณีย์"
-    zone: "โซน"
-    zones: "โซน"
+    weight: น้ำหนัก
+    what_is_a_cvv: อะไรคือ (CVV) บนบัตรเครดิต?
+    what_is_this: นี่คืออะไร
+    width: กว้าง
+    year: ปี
+    you_have_no_orders_yet: คุณยังไม่มีรายการสั่งซื้อ
+    your_cart_is_empty: ตะกร้าคุณว่างเปล่า
+    your_order_is_empty_add_product: คุณไม่มีรายการสั่งซื้อ กรุณาค้นหาและเพิ่มสินค้าด้านบน
+    zip: รหัสไปรษณีย์
+    zipcode: รหัสไปรษณีย์
+    zone: โซน
+    zones: โซน
+    canceled: ยกเลิก
+    cannot_create_payment_link: กรุณาเลือกวิธีการชำระก่อน
+    inventory_states:
+      canceled: ยกเลิก
+      returned: คืน
+      shipped: ส่งแล้ว
+    no_resource_found_link: เพิ่ม
+    number: หมายเลข
+    store_credit:
+      display_action:
+        adjustment: แก้ไขรายการ
+        credit: เครดิต
+        void: เครดิต
+        admin:
+          authorize:
+    store_credit_category:
+      default: ค่าเริ่มต้น
+  activemodel:
+    attributes:
+      spree/order_cancellations:
+        quantity: จำนวน
+        state: จังหวัด
+        shipment: การส่ง
+        cancel: ยกเลิก


### PR DESCRIPTION
Recent changes made to admin translations in solidus moved many of the keys. This was done to better use the ActiveModel translation conventions.

I wrote a [script](https://github.com/StemboltHQ/solidus_i18n_convert) that scans through the locale files in solidus_i18n looking for missing keys when compared to `en.yml` in core. Since these translations are just moved, the script attempts to make the same moves in this locale as were made for english.

Reviews would be appreciated to find any blatant mistranslations.
