### PR TITLE
Convert ru translations from solidus 1.2 -> 1.3

### DIFF
--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,16 +1,18 @@
+---
 ru:
   activerecord:
     attributes:
       spree/address:
-        address1: "Адрес"
-        address2: "адрес (продолж.)"
-        city: "Населённый пункт"
-        country: "Страна"
-        firstname: "Имя"
-        lastname: "Фамилия"
-        phone: "Телефон"
-        state: "Область/Регион"
-        zipcode: "Почтовый индекс"
+        address1: Адрес
+        address2: адрес (продолж.)
+        city: Населённый пункт
+        country: Страна
+        firstname: Имя
+        lastname: Фамилия
+        phone: Телефон
+        state: Область/Регион
+        zipcode: Почтовый индекс
+        company: Компания
       spree/calculator/tiered_flat_rate:
         preferred_base_amount:
         preferred_tiers:
@@ -21,94 +23,126 @@ ru:
         iso: ISO
         iso3: ISO3
         iso_name: ISO-имя
-        name: "Название"
+        name: Название
         numcode: ISO-код
+        states_required: Регионы обязательны
       spree/credit_card:
         base:
-        cc_type: "Тип кредитной карты"
-        month: "Месяц"
+        cc_type: Тип кредитной карты
+        month: Месяц
         name:
-        number: "Номер"
-        verification_value: "Значение проверки"
-        year: "Год"
+        number: Номер
+        verification_value: Значение проверки
+        year: Год
+        card_code: Код карты
+        expiration: Окончание действия
       spree/inventory_unit:
-        state: "Состояние"
+        state: Состояние
       spree/line_item:
-        price: "Цена"
-        quantity: "Кол-во"
+        price: Цена
+        quantity: Кол-во
+        description: Описание товара
+        name: Наименование
+        total:
       spree/option_type:
-        name: "Название"
-        presentation: "Представление"
+        name: Название
+        presentation: Представление
       spree/order:
-        checkout_complete: "Оформление заказа завершено"
-        completed_at: "Завершено"
-        considered_risky: "Статус риска"
-        coupon_code: "Код купона"
-        created_at: "Дата заказа"
+        checkout_complete: Оформление заказа завершено
+        completed_at: Завершено
+        considered_risky: Статус риска
+        coupon_code: Код купона
+        created_at: Дата заказа
         email: E-mail покупателя
         ip_address: IP-адрес
-        item_total: "Итого по товарам"
-        number: "Номер"
-        payment_state: "Состояние оплаты"
-        shipment_state: "Состояние доставки"
-        special_instructions: "Специальные инструкции"
-        state: "Состояние"
-        total: "Итого по заказу"
+        item_total: Итого по товарам
+        number: Номер
+        payment_state: Состояние оплаты
+        shipment_state: Состояние доставки
+        special_instructions: Специальные инструкции
+        state: Состояние
+        total: Итого по заказу
+        additional_tax_total: Налог
+        approved_at: Подтверждено
+        approver_id: Подтвердил(а)
+        canceled_at:
+        canceler_id:
+        included_tax_total: Вкл. налоги
+        shipment_total: Всего к доставке
       spree/order/bill_address:
-        address1: "Улица"
-        city: "Город"
-        firstname: "Имя"
-        lastname: "Фамилия"
-        phone: "Телефон"
-        state: "Область/Регион"
-        zipcode: "Почтовый индекс"
+        address1: Улица
+        city: Город
+        firstname: Имя
+        lastname: Фамилия
+        phone: Телефон
+        state: Область/Регион
+        zipcode: Почтовый индекс
       spree/order/ship_address:
-        address1: "Улица"
-        city: "Город"
-        firstname: "Имя"
-        lastname: "Фамилия"
-        phone: "Телефон"
-        state: "Область/Регион"
-        zipcode: "Почтовый индекс"
+        address1: Улица
+        city: Город
+        firstname: Имя
+        lastname: Фамилия
+        phone: Телефон
+        state: Область/Регион
+        zipcode: Почтовый индекс
       spree/payment:
-        amount: "Количество"
+        amount: Количество
+        number:
+        response_code:
+        state: Статус платежа
       spree/payment_method:
-        name: "Название"
+        name: Название
+        active: Активен
+        auto_capture: Автозахват
+        description: Описание
+        display_on: Показать
+        type: Провайдер
       spree/product:
-        available_on: "Доступен с"
-        cost_currency: "Валюта"
-        cost_price: "Себестоимость"
-        description: "Описание"
-        master_price: "Цена"
-        name: "Название"
-        on_hand: "На складе"
-        shipping_category: "Категория доставки"
-        tax_category: "Категория налогов"
+        available_on: Доступен с
+        cost_currency: Валюта
+        cost_price: Себестоимость
+        description: Описание
+        master_price: Цена
+        name: Название
+        on_hand: На складе
+        shipping_category: Категория доставки
+        tax_category: Категория налогов
+        depth: Глубина
+        height: Высота
+        meta_description: Описание
+        meta_keywords: Ключевые слова
+        meta_title:
+        price: Основная цена
+        promotionable:
+        slug: Ссылка
+        weight: Вес
+        width: Ширина
       spree/promotion:
-        advertise: "Рекламировать"
-        code: "Код"
-        description: "Описание"
-        event_name: "Название события"
-        expires_at: "Истекает в"
-        name: "Название"
-        path: "Путь"
-        starts_at: "Начинается"
-        usage_limit: "Лимит использования"
+        advertise: Рекламировать
+        code: Код
+        description: Описание
+        event_name: Название события
+        expires_at: Истекает в
+        name: Название
+        path: Путь
+        starts_at: Начинается
+        usage_limit: Лимит использования
       spree/promotion_category:
-        name: "Название"
-        code: "Код"
+        name: Название
+        code: Код
       spree/property:
-        name: "Название"
-        presentation: "Представление"
+        name: Название
+        presentation: Представление
       spree/prototype:
-        name: "Название"
+        name: Название
       spree/return_authorization:
-        amount: "Сумма"
+        amount: Сумма
+        pre_tax_total:
       spree/role:
-        name: "Название"
+        name: Название
       spree/state:
-        abbr: "Аббревиатура"
-        name: "Название"
+        abbr: Аббревиатура
+        name: Название
       spree/state_change:
         state_changes:
         state_from:
@@ -118,41 +152,162 @@ ru:
         updated:
         user:
       spree/store:
-        mail_from_address: "Отсылать почту как"
+        mail_from_address: Отсылать почту как
         meta_description: Meta-описание
         meta_keywords: Meta ключевые слова
-        name: "Название сайта"
+        name: Название сайта
         seo_title: SEO-заголовок
         url: URL-адрес сайта
       spree/tax_category:
-        description: "Описание"
-        name: "Название"
+        description: Описание
+        name: Название
+        is_default: По умолчанию
+        tax_code:
       spree/tax_rate:
-        amount: "Ставка"
-        included_in_price: "Включено в цену"
-        show_rate_in_label: "Показывать ставку в метке"
+        amount: Ставка
+        included_in_price: Включено в цену
+        show_rate_in_label: Показывать ставку в метке
+        name: Наименование
       spree/taxon:
-        name: "Название"
-        permalink: "Постоянная ссылка"
-        position: "Позиция"
+        name: Название
+        permalink: Постоянная ссылка
+        position: Позиция
+        description: Описание
+        icon: Иконка
+        meta_description: Описание
+        meta_keywords: Ключевые слова
+        meta_title:
       spree/taxonomy:
-        name: "Название"
+        name: Название
       spree/user:
         email: Email
-        password: "Пароль"
-        password_confirmation: "Подтверждение пароля"
+        password: Пароль
+        password_confirmation: Подтверждение пароля
       spree/variant:
-        cost_currency: "Валюта"
-        cost_price: "Себестоимость"
-        depth: "Толщина"
-        height: "Высота"
-        price: "Цена"
-        sku: "Артикул"
-        weight: "Вес"
-        width: "Ширина"
+        cost_currency: Валюта
+        cost_price: Себестоимость
+        depth: Толщина
+        height: Высота
+        price: Цена
+        sku: Артикул
+        weight: Вес
+        width: Ширина
       spree/zone:
-        description: "Описание"
-        name: "Название"
+        description: Описание
+        name: Название
+        default_tax: Стандартный налоговый регион
+      spree/adjustment:
+        adjustable: Корректируемое
+        amount: Сумма
+        label: Описание
+        name: Наименование
+        state: Регион/Область
+        adjustment_reason_id: Причина
+      spree/adjustment_reason:
+        active: Активен
+        code: Кодовое слово
+        name: Наименование
+        state: Регион/Область
+      spree/carton:
+        tracking: Отслеживание
+      spree/customer_return:
+        number: Номер возврата
+        pre_tax_total:
+        total: Итого
+        reimbursement_status:
+        name: Наименование
+      spree/image:
+        alt: Альтернативный текст
+        attachment: Имя файла
+      spree/legacy_user:
+        email: Электронная почта
+        password: Пароль
+        password_confirmation: Подтверждение пароля
+      spree/option_value:
+        name: Наименование
+        presentation: Отображать как
+      spree/product_property:
+        value: Значение
+      spree/refund:
+        amount: Сумма
+        description: Описание
+        refund_reason_id: Причина
+      spree/refund_reason:
+        active: Активен
+        name: Наименование
+        code: Кодовое слово
+      spree/reimbursement:
+        number: Номер
+        reimbursement_status: Статус
+        total: Итого
+      spree/reimbursement/credit:
+        amount: Сумма
+      spree/reimbursement_type:
+        name: Наименование
+        type: Тип
+      spree/return_item:
+        acceptance_status:
+        acceptance_status_errors:
+        charged:
+        exchange_variant:
+        inventory_unit_state: Регион/Область
+        override_reimbursement_type_id:
+        preferred_reimbursement_type_id:
+        reception_status:
+        return_reason: Причина
+        total: Итого
+      spree/return_reason:
+        name: Наименование
+        active: Активен
+        memo:
+        number: Номер RMA
+        state: Регион/Область
+      spree/shipping_category:
+        name: Наименование
+      spree/shipment:
+        tracking: Трекинговый номер
+      spree/shipping_method:
+        admin_name: Внутреннее имя
+        code: Кодовое слово
+        display_on: Показать
+        name: Наименование
+        tracking_url: Трекинговый URL
+      spree/shipping_rate:
+        tax_rate: Ставка налога
+        amount: Сумма
+      spree/store_credit:
+        amount: Сумма
+        memo:
+      spree/store_credit_event:
+        action: Действие
+      spree/stock_item:
+        count_on_hand: Наличие
+      spree/stock_location:
+        admin_name: Внутреннее имя
+        active: Активен
+        address1: Адрес
+        address2: Адрес (строка 2)
+        backorderable_default: Предзаказ по умолчанию
+        city: Город
+        code: Кодовое слово
+        country_id: Страна
+        default: По умолчанию
+        internal_name: Внутреннее имя
+        name: Наименование
+        phone: Телефон
+        propagate_all_variants: Применить ко всем вариантам
+        state_id: Регион/Область
+        zipcode: Индекс
+      spree/stock_movement:
+        action: Действие
+        quantity: Количество
+      spree/stock_transfer:
+        created_at: Создано в
+        description: Описание
+        tracking_number: Трекинговый номер
+      spree/tracker:
+        analytics_id: Google Analytics ID
+        active: Активен
     errors:
       models:
         spree/calculator/tiered_flat_rate:
@@ -175,7 +330,7 @@ ru:
         spree/credit_card:
           attributes:
             base:
-              card_expired: "Срок действия карты истек"
+              card_expired: Срок действия карты истек
               expiry_invalid:
         spree/line_item:
           attributes:
@@ -201,415 +356,449 @@ ru:
               cannot_destroy_default_store:
     models:
       spree/address:
-        many: "Адресов"
-        one: "Адрес"
-        other: "Адреса"
+        many: Адресов
+        one: Адрес
+        other: Адреса
       spree/country:
-        many: "Стран"
-        one: "Страна"
-        other: "Страны"
+        many: Стран
+        one: Страна
+        other: Страны
       spree/credit_card:
-        many: "Кредитных карт"
-        one: "Кредитная карта"
-        other: "Кредитные карты"
+        many: Кредитных карт
+        one: Кредитная карта
+        other: Кредитные карты
       spree/customer_return:
-        many: "Возвратов покупателю"
-        one: "Возврат покупателю"
-        other: "Возвраты покупателю"
+        many: Возвратов покупателю
+        one: Возврат покупателю
+        other: Возвраты покупателю
       spree/inventory_unit:
-        many: "Единиц"
-        one: "Единица"
-        other: "Единицы"
+        many: Единиц
+        one: Единица
+        other: Единицы
       spree/line_item:
-        many: "Позиций"
-        one: "Позиция"
-        other: "Позиции"
+        many: Позиций
+        one: Позиция
+        other: Позиции
       spree/option_type:
-        many: "Товарных опций"
-        one: "Товарная опция"
-        other: "Товарные опции"
+        many: Товарных опций
+        one: Товарная опция
+        other: Товарные опции
       spree/option_value:
+        one: Возможное значение опции
+        other: Возможные значения опции
       spree/order:
-        many: "Заказов"
-        one: "Заказ"
-        other: "Заказы"
+        many: Заказов
+        one: Заказ
+        other: Заказы
       spree/payment:
-        many: "Платежей"
-        one: "Платёж"
-        other: "Платежи"
+        many: Платежей
+        one: Платёж
+        other: Платежи
       spree/payment_method:
-        many: "Способов оплаты"
-        one: "Способ оплаты"
-        other: "Способы оплаты"
+        many: Способов оплаты
+        one: Способ оплаты
+        other: Способы оплаты
       spree/product:
-        many: "Товаров"
-        one: "Товар"
-        other: "Товары"
+        many: Товаров
+        one: Товар
+        other: Товары
       spree/promotion:
-        many: "Акций"
-        one: "Акция"
-        other: "Акции"
+        many: Акций
+        one: Акция
+        other: Акции
       spree/promotion_category:
-        many: "Категорий акций"
-        one: "Категория акций"
-        other: "Категории акций"
+        many: Категорий акций
+        one: Категория акций
+        other: Категории акций
       spree/property:
-        many: "Свойств"
-        one: "Свойство"
-        other: "Свойства"
+        many: Свойств
+        one: Свойство
+        other: Свойства
       spree/prototype:
-        many: "Прототипов"
-        one: "Прототип"
-        other: "Прототипы"
+        many: Прототипов
+        one: Прототип
+        other: Прототипы
       spree/refund_reason:
-        many: "Причин возврата"
-        one: "Причина возврата"
-        other: "Причины возврата"
+        many: Причин возврата
+        one: Причина возврата
+        other: Причины возврата
       spree/reimbursement:
+        one:
+        other:
       spree/reimbursement_type:
-        many: "Типов возврата"
-        one: "Тип возврата"
-        other: "Типы возврата"
+        many: Типов возврата
+        one: Тип возврата
+        other: Типы возврата
       spree/return_authorization:
-        many: "Разрешений на возврат"
-        one: "Разрешение на возврат"
-        other: "Разрешения на возврат"
+        many: Разрешений на возврат
+        one: Разрешение на возврат
+        other: Разрешения на возврат
       spree/return_authorization_reason:
-        many: "Причин разрешения на возврат"
-        one: "Причина разрешения на возврат"
-        other: "Причины разрешения на возврат"
+        many: Причин разрешения на возврат
+        one: Причина разрешения на возврат
+        other: Причины разрешения на возврат
       spree/role:
-        many: "Ролей"
-        one: "Роль"
-        other: "Роли"
+        many: Ролей
+        one: Роль
+        other: Роли
       spree/shipment:
-        many: "Доставок"
-        one: "Доставка"
-        other: "Доставки"
+        many: Доставок
+        one: Доставка
+        other: Доставки
       spree/shipping_category:
-        many: "Категорий доставки"
-        one: "Категория доставки"
-        other: "Категории доставки"
+        many: Категорий доставки
+        one: Категория доставки
+        other: Категории доставки
       spree/shipping_method:
         many: Cпособов доставки
         one: Cпособ доставки
         other: Cпособы доставки
       spree/state:
-        many: "Областей/Регионов"
-        one: "Область/Регион"
-        other: "Области/Регионы"
+        many: Областей/Регионов
+        one: Область/Регион
+        other: Области/Регионы
       spree/state_change:
       spree/stock_location:
-        many: "Расположений складов"
-        one: "Расположение склада"
-        other: "Расположения складов"
+        many: Расположений складов
+        one: Расположение склада
+        other: Расположения складов
       spree/stock_movement:
+        other: Перемещения товаров
       spree/stock_transfer:
-        many: "Перемещений по складам"
-        one: "Перемещение по складам"
-        other: "Перемещения по складам"
+        many: Перемещений по складам
+        one: Перемещение по складам
+        other: Перемещения по складам
       spree/tax_category:
-        many: "Категорий налогов"
-        one: "Категория налогов"
-        other: "Категории налогов"
+        many: Категорий налогов
+        one: Категория налогов
+        other: Категории налогов
       spree/tax_rate:
-        many: "Ставок налога"
-        one: "Ставка налога"
-        other: "Ставки налога"
+        many: Ставок налога
+        one: Ставка налога
+        other: Ставки налога
       spree/taxon:
-        many: "Таксонов"
-        one: "Таксон"
-        other: "Таксона"
+        many: Таксонов
+        one: Таксон
+        other: Таксона
       spree/taxonomy:
-        many: "Таксономий"
-        one: "Таксономия"
-        other: "Таксономии"
+        many: Таксономий
+        one: Таксономия
+        other: Таксономии
       spree/tracker:
-        many: "Трекеров"
-        one: "Трекер"
-        other: "Трекеры"
+        many: Трекеров
+        one: Трекер
+        other: Трекеры
       spree/user:
-        many: "Пользователей"
-        one: "Пользователь"
-        other: "Пользователя"
+        many: Пользователей
+        one: Пользователь
+        other: Пользователя
       spree/variant:
-        many: "Вариантов"
-        one: "Вариант"
-        other: "Варианта"
+        many: Вариантов
+        one: Вариант
+        other: Варианта
       spree/zone:
-        many: "Зон"
-        one: "Зона"
-        other: "Зоны"
+        many: Зон
+        one: Зона
+        other: Зоны
+      spree/adjustment:
+        one: Корректировка
+        other: Корректировки
+      spree/calculator:
+        one: Калькулятор
+      spree/legacy_user:
+        one: Пользователь
+        other: Пользователи
+      spree/log_entry:
+        other:
+      spree/product_property:
+        other: Свойства товара
+      spree/refund:
+        one: Возврат
+        other:
+      spree/store_credit_category:
+        one: Категория
+        other: Категории
   devise:
     confirmations:
-      confirmed: "Ваш аккаунт успешно активирован. Теперь вы авторизованы."
-      send_instructions: "Вы получите письмо с инструкциями о том как активировать ваш аккаунт в течении нескольких минут."
+      confirmed: Ваш аккаунт успешно активирован. Теперь вы авторизованы.
+      send_instructions: Вы получите письмо с инструкциями о том как активировать ваш аккаунт в течении нескольких минут.
     failure:
-      inactive: "Ваш аккаунт еще не был активирован."
-      invalid: "Неверный логин или пароль."
-      invalid_token: "Неверный токен аутентификации."
-      locked: "Учетная запись заблокирована."
-      timeout: "Ваша сессия истекла. Войдите заново, чтобы продолжить."
-      unauthenticated: "Вам требуется войти или зарегистрироваться перед тем, как продолжить."
-      unconfirmed: "Вы должны подтвердить свою учетную запись перед тем, как продолжить."
+      inactive: Ваш аккаунт еще не был активирован.
+      invalid: Неверный логин или пароль.
+      invalid_token: Неверный токен аутентификации.
+      locked: Учетная запись заблокирована.
+      timeout: Ваша сессия истекла. Войдите заново, чтобы продолжить.
+      unauthenticated: Вам требуется войти или зарегистрироваться перед тем, как продолжить.
+      unconfirmed: Вы должны подтвердить свою учетную запись перед тем, как продолжить.
     mailer:
       confirmation_instructions:
-        subject: "Инструкции для подтверждения"
+        subject: Инструкции для подтверждения
       reset_password_instructions:
-        subject: "Инструкции по сбросу пароля"
+        subject: Инструкции по сбросу пароля
       unlock_instructions:
-        subject: "Инструкции по разблокированию"
+        subject: Инструкции по разблокированию
     oauth_callbacks:
-      failure: "Не смогли войти с %{kind} потому что %{reason}."
-      success: "Успешно вошли с %{kind} аккаунта."
+      failure: Не смогли войти с %{kind} потому что %{reason}.
+      success: Успешно вошли с %{kind} аккаунта.
     unlocks:
-      send_instructions: "Вы получите письмо с инструкциями о том как разблокировать ваш аккаунт в течении неско��ьких минут."
-      unlocked: "Ваш аккаунт был успешно разблокирован. Сейчас вы вошли в систему."
+      send_instructions: Вы получите письмо с инструкциями о том как разблокировать ваш аккаунт в течении неско��ьких минут.
+      unlocked: Ваш аккаунт был успешно разблокирован. Сейчас вы вошли в систему.
     user_passwords:
       user:
-        cannot_be_blank: "Пароль не может быть пустым."
-        send_instructions: "Вы получите письмо с инструкциями о том, как изменить ваш пароль в течении нескольких минут."
-        updated: "Ваш пароль был успешно изменен. Сейчас вы в системе."
+        cannot_be_blank: Пароль не может быть пустым.
+        send_instructions: Вы получите письмо с инструкциями о том, как изменить ваш пароль в течении нескольких минут.
+        updated: Ваш пароль был успешно изменен. Сейчас вы в системе.
     user_registrations:
-      destroyed: "До встречи! Ваш аккаунт был успешно удален. Надеемся увидеть вас в скором будущем."
-      inactive_signed_up: "Вы успешно зарегистрировались. К сожалению, вы не смогли войти, потому что ваш аккаунт %{reason}."
-      signed_up: "Приветствуем! Вы успешно зарегистрировались."
-      updated: "Ваш аккаунт был успешно обновлен."
+      destroyed: До встречи! Ваш аккаунт был успешно удален. Надеемся увидеть вас в скором будущем.
+      inactive_signed_up: Вы успешно зарегистрировались. К сожалению, вы не смогли войти, потому что ваш аккаунт %{reason}.
+      signed_up: Приветствуем! Вы успешно зарегистрировались.
+      updated: Ваш аккаунт был успешно обновлен.
     user_sessions:
-      signed_in: "Вы успешно вошли."
-      signed_out: "Вы успешно вышли."
+      signed_in: Вы успешно вошли.
+      signed_out: Вы успешно вышли.
   errors:
     messages:
-      already_confirmed: "уже был подтвержден"
-      not_found: "не найден"
-      not_locked: "не был заблокирован"
+      already_confirmed: уже был подтвержден
+      not_found: не найден
+      not_locked: не был заблокирован
       not_saved:
         many: "%{count} ошибок препятствуют сохранению %{resource}:"
-        one: "Одна ошибка препятствует сохранению %{resource}:"
+        one: 'Одна ошибка препятствует сохранению %{resource}:'
         other: "%{count} ошибки препятствуют сохранению %{resource}:"
   spree:
-    abbreviation: "Аббревиатура"
+    abbreviation: Аббревиатура
     accept:
     acceptance_errors:
     acceptance_status:
     accepted:
-    account: "Учетная запись"
-    account_updated: "Учетная запись обновлена!"
-    action: "Действие"
+    account: Учетная запись
+    account_updated: Учетная запись обновлена!
+    action: Действие
     actions:
-      cancel: "Отменить"
-      continue: "Продолжить"
-      create: "Создать"
-      destroy: "Удалить"
-      edit: "Редактировать"
-      list: "Показать"
-      listing: "Список"
-      new: "Новый"
+      cancel: Отменить
+      continue: Продолжить
+      create: Создать
+      destroy: Удалить
+      edit: Редактировать
+      list: Показать
+      listing: Список
+      new: Новый
       refund:
-      save: "Сохранить"
-      update: "Изменить"
-    activate: "Активировать"
-    active: "Активен"
-    add: "Добавить"
-    add_action_of_type: "Добавить действие типа"
-    add_country: "Добавить страну"
-    add_coupon_code: "Добавить код купона"
-    add_new_header: "Добавить новый заголовок"
-    add_new_style: "Добавить новый стиль"
-    add_one: "Добавить"
-    add_option_value: "Добавить значение опции"
-    add_product: "Добавить товар"
-    add_product_properties: "Добавить свойства товара"
-    add_rule_of_type: "Добавить правило типа"
-    add_state: "Добавить регион/область"
-    add_stock: "Добавить склад"
-    add_stock_management: "Добавить управление запасами"
-    add_to_cart: "Добавить в корзину"
-    add_variant: "Добавить вариант"
-    additional_item: "Ставка для дополнительных наименований"
-    address1: "Адрес"
-    address2: "адрес (продолж.)"
-    adjustable: "Корректируемое"
-    adjustment: "Корректировка"
-    adjustment_amount: "Количество"
-    adjustment_successfully_closed: "Корректировка была успешно закрыта!"
-    adjustment_successfully_opened: "Корректировка была успешно открыта!"
-    adjustment_total: "Итого (коррект.)"
-    adjustments: "Корректировки"
+      save: Сохранить
+      update: Изменить
+      add: Добавить
+      delete: Удалить
+      remove: Убрать
+      ship: доставка
+      split: Разделить
+    activate: Активировать
+    active: Активен
+    add: Добавить
+    add_action_of_type: Добавить действие типа
+    add_country: Добавить страну
+    add_coupon_code: Добавить код купона
+    add_new_header: Добавить новый заголовок
+    add_new_style: Добавить новый стиль
+    add_one: Добавить
+    add_option_value: Добавить значение опции
+    add_product: Добавить товар
+    add_product_properties: Добавить свойства товара
+    add_rule_of_type: Добавить правило типа
+    add_state: Добавить регион/область
+    add_stock: Добавить склад
+    add_stock_management: Добавить управление запасами
+    add_to_cart: Добавить в корзину
+    add_variant: Добавить вариант
+    additional_item: Ставка для дополнительных наименований
+    address1: Адрес
+    address2: адрес (продолж.)
+    adjustable: Корректируемое
+    adjustment: Корректировка
+    adjustment_amount: Количество
+    adjustment_successfully_closed: Корректировка была успешно закрыта!
+    adjustment_successfully_opened: Корректировка была успешно открыта!
+    adjustment_total: Итого (коррект.)
+    adjustments: Корректировки
     admin:
       tab:
-        configuration: "Настройки"
-        option_types: "Товарные опции"
-        orders: "Заказы"
-        overview: "Обзор"
-        products: "Товары"
-        promotions: "Акции"
-        promotion_categories: "Категории акций"
-        properties: "Свойства"
-        prototypes: "Прототипы"
-        reports: "Отчёты"
-        taxonomies: "Таксономии"
-        taxons: "Таксоны"
-        users: "Пользователи"
+        configuration: Настройки
+        option_types: Товарные опции
+        orders: Заказы
+        overview: Обзор
+        products: Товары
+        promotions: Акции
+        promotion_categories: Категории акций
+        properties: Свойства
+        prototypes: Прототипы
+        reports: Отчёты
+        taxonomies: Таксономии
+        taxons: Таксоны
+        users: Пользователи
+        checkout: Оформление заказа
+        general: Основные
+        payments: Платежи
+        settings: Настройки
+        shipping: Доставка
+        stock: Управление запасами
       user:
-        account: "Учетная запись"
-        addresses: "Адреса"
-        items: "Товары"
-        items_purchased: "Купленные товары"
-        order_history: "История заказов"
+        account: Учетная запись
+        addresses: Адреса
+        items: Товары
+        items_purchased: Купленные товары
+        order_history: История заказов
         order_num:
-        orders: "Заказы"
-        user_information: "Информация"
-    administration: "Администрирование"
+        orders: Заказы
+        user_information: Информация
+    administration: Администрирование
     advertise:
-    agree_to_privacy_policy: "Согласиться с Политикой Конфиденциальности"
-    agree_to_terms_of_service: "Согласиться с Уловиями обслуживания"
-    all: "все"
-    all_adjustments_closed: "Все корректировки успешно закрыты!"
-    all_adjustments_opened: "Все корректировки успешно открыты!"
-    all_departments: "Все разделы"
+    agree_to_privacy_policy: Согласиться с Политикой Конфиденциальности
+    agree_to_terms_of_service: Согласиться с Уловиями обслуживания
+    all: все
+    all_adjustments_closed: Все корректировки успешно закрыты!
+    all_adjustments_opened: Все корректировки успешно открыты!
+    all_departments: Все разделы
     all_items_have_been_returned:
-    allow_ssl_in_development_and_test: "Разрешить SSL для development и test режимов"
-    allow_ssl_in_production: "Разрешить SSL для production режима"
-    allow_ssl_in_staging: "Разрешить SSL для staging режима"
-    already_signed_up_for_analytics: "Вы уже зарегистировались в Spree Analytics"
-    alt_text: "Альтернативный текст"
-    alternative_phone: "Дополнительный телефон"
-    amount: "Сумма"
-    analytics_desc_header_1: "Аналитика Spree"
-    analytics_desc_header_2: "Аналитика в прямом эфире добавлена на Spree dashboard"
-    analytics_desc_list_1: "Получать информацию о продажах в реальном времени"
-    analytics_desc_list_2: "Бесплатный аккаунт Spree требуется для активации"
-    analytics_desc_list_3: "Отсутствует код для установки"
-    analytics_desc_list_4: "Полностью бесплатный!"
-    analytics_trackers: "Трекеры веб-аналитики"
-    and: "и"
-    approve: "Подтвердить"
-    approved_at: "Подтверждено"
-    approver: "Подтвердил(а)"
-    are_you_sure: "Вы уверены"
-    are_you_sure_delete: "Вы уверены, что хотите удалить эту запись?"
-    associated_adjustment_closed: "Связанная корректировка закрыта, и не будет пересчитана. Хотите ли вы открыть её?"
-    at_symbol: '@'
-    authorization_failure: "Ошибка авторизации"
+    allow_ssl_in_development_and_test: Разрешить SSL для development и test режимов
+    allow_ssl_in_production: Разрешить SSL для production режима
+    allow_ssl_in_staging: Разрешить SSL для staging режима
+    already_signed_up_for_analytics: Вы уже зарегистировались в Spree Analytics
+    alt_text: Альтернативный текст
+    alternative_phone: Дополнительный телефон
+    amount: Сумма
+    analytics_desc_header_1: Аналитика Spree
+    analytics_desc_header_2: Аналитика в прямом эфире добавлена на Spree dashboard
+    analytics_desc_list_1: Получать информацию о продажах в реальном времени
+    analytics_desc_list_2: Бесплатный аккаунт Spree требуется для активации
+    analytics_desc_list_3: Отсутствует код для установки
+    analytics_desc_list_4: Полностью бесплатный!
+    analytics_trackers: Трекеры веб-аналитики
+    and: и
+    approve: Подтвердить
+    approved_at: Подтверждено
+    approver: Подтвердил(а)
+    are_you_sure: Вы уверены
+    are_you_sure_delete: Вы уверены, что хотите удалить эту запись?
+    associated_adjustment_closed: Связанная корректировка закрыта, и не будет пересчитана. Хотите ли вы открыть её?
+    at_symbol: "@"
+    authorization_failure: Ошибка авторизации
     authorized:
-    auto_capture: "Автозахват"
-    available_on: "Доступно с"
-    average_order_value: "Средняя сумма заказа"
+    auto_capture: Автозахват
+    available_on: Доступно с
+    average_order_value: Средняя сумма заказа
     avs_response:
-    back: "Назад"
-    back_end: "в администраторском интерфейсе"
+    back: Назад
+    back_end: в администраторском интерфейсе
     back_to_payment:
-    back_to_resource_list: "Назад к списку"
-    back_to_rma_reason_list: "Назад к списку причин разрешения на возврат"
-    back_to_store: "Вернуться в магазин"
-    back_to_users_list: "Назад к списку пользователей"
-    backorderable: "Возможен предзаказ"
-    backorderable_default: "Предзаказ по умолчанию"
-    backordered: "Предзаказано"
-    backorders_allowed: "Предзаказы разрешены"
-    balance_due: "Дебетовое сальдо"
+    back_to_resource_list: Назад к списку
+    back_to_rma_reason_list: Назад к списку причин разрешения на возврат
+    back_to_store: Вернуться в магазин
+    back_to_users_list: Назад к списку пользователей
+    backorderable: Возможен предзаказ
+    backorderable_default: Предзаказ по умолчанию
+    backordered: Предзаказано
+    backorders_allowed: Предзаказы разрешены
+    balance_due: Дебетовое сальдо
     base_amount:
     base_percent:
-    bill_address: "Платёжный адрес"
-    billing: "Биллинг"
-    billing_address: "Платёжный адрес"
-    both: "везде"
+    bill_address: Платёжный адрес
+    billing: Биллинг
+    billing_address: Платёжный адрес
+    both: везде
     calculated_reimbursements:
-    calculator: "Калькулятор"
-    calculator_settings_warning: "При изменении типа калькулятора, вы должны сохранить это изменение, прежде, чем вы сможете изменить настройки калькулятора."
-    cancel: "Отмена"
+    calculator: Калькулятор
+    calculator_settings_warning: При изменении типа калькулятора, вы должны сохранить это изменение, прежде, чем вы сможете изменить настройки калькулятора.
+    cancel: Отмена
     canceled_at:
     canceler:
     cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: "Нельзя создать платеж для заказа, если не настроен ни один из способов оплаты."
-    cannot_create_returns: "Невозможно оформить возврат, т.к. этот заказ ещё не отправлен."
-    cannot_perform_operation: "Невозможно выполнить требуемую операцию"
-    cannot_set_shipping_method_without_address: "Невозможно выбрать способ доставки, пока данные пользователя не указаны."
-    capture: "Провести платёж"
-    capture_events: "Платежи"
-    card_code: "Код карты"
-    card_number: "Номер карты"
+    cannot_create_payment_without_payment_methods: Нельзя создать платеж для заказа, если не настроен ни один из способов оплаты.
+    cannot_create_returns: Невозможно оформить возврат, т.к. этот заказ ещё не отправлен.
+    cannot_perform_operation: Невозможно выполнить требуемую операцию
+    cannot_set_shipping_method_without_address: Невозможно выбрать способ доставки, пока данные пользователя не указаны.
+    capture: Провести платёж
+    capture_events: Платежи
+    card_code: Код карты
+    card_number: Номер карты
     card_type:
-    card_type_is: "Тип карты"
-    cart: "Корзина"
+    card_type_is: Тип карты
+    cart: Корзина
     cart_subtotal:
-    categories: "Категории"
-    category: "Категория"
+    categories: Категории
+    category: Категория
     charged:
-    check_for_spree_alerts: "Проверить оповещения Spree"
-    checkout: "Оформление заказа"
-    choose_a_customer: "Выберите клиента"
-    choose_a_taxon_to_sort_products_for: "Выберите таксон для сортировки товаров"
-    choose_currency: "Выбрать валюту"
-    choose_dashboard_locale: "Выбрать язык отображения панели управления"
+    check_for_spree_alerts: Проверить оповещения Spree
+    checkout: Оформление заказа
+    choose_a_customer: Выберите клиента
+    choose_a_taxon_to_sort_products_for: Выберите таксон для сортировки товаров
+    choose_currency: Выбрать валюту
+    choose_dashboard_locale: Выбрать язык отображения панели управления
     choose_location:
-    city: "Город"
-    clear_cache: "Очистить кэш"
+    city: Город
+    clear_cache: Очистить кэш
     clear_cache_ok:
-    clear_cache_warning: "Внимание, данное действие приведёт к очистке кэша"
-    click_and_drag_on_the_products_to_sort_them: "Перетаскивайте товары мышкой для сортировки"
-    clone: "Копировать"
-    close: "Закрыть"
-    close_all_adjustments: "Закрыть все корректировки"
-    code: "Кодовое слово"
-    company: "Компания"
-    complete: "Завершено"
-    configuration: "Конфигурация"
-    configurations: "Конфигурация"
-    confirm: "Подтвердить"
-    confirm_delete: "Подтверждение удаления"
-    confirm_password: "Подтверждение пароля"
-    continue: "Продолжить"
-    continue_shopping: "Продолжить покупки"
-    cost_currency: "Валюта"
-    cost_price: "Себестоимость"
-    could_not_connect_to_jirafe: "Невозможно синхоринизороваться с Jirafe. Попытка будет повторена позже."
+    clear_cache_warning: Внимание, данное действие приведёт к очистке кэша
+    click_and_drag_on_the_products_to_sort_them: Перетаскивайте товары мышкой для сортировки
+    clone: Копировать
+    close: Закрыть
+    close_all_adjustments: Закрыть все корректировки
+    code: Кодовое слово
+    company: Компания
+    complete: Завершено
+    configuration: Конфигурация
+    configurations: Конфигурация
+    confirm: Подтвердить
+    confirm_delete: Подтверждение удаления
+    confirm_password: Подтверждение пароля
+    continue: Продолжить
+    continue_shopping: Продолжить покупки
+    cost_currency: Валюта
+    cost_price: Себестоимость
+    could_not_connect_to_jirafe: Невозможно синхоринизороваться с Jirafe. Попытка будет повторена позже.
     could_not_create_customer_return:
-    could_not_create_stock_movement: "Возникла проблема при сохранении перемещения запасов. Пожалуйста, попытайтесь снова."
-    count_on_hand: "Наличие"
-    countries: "Страны"
-    country: "Страна"
-    country_based: "Страна"
-    country_name: "Имя"
+    could_not_create_stock_movement: Возникла проблема при сохранении перемещения запасов. Пожалуйста, попытайтесь снова.
+    count_on_hand: Наличие
+    countries: Страны
+    country: Страна
+    country_based: Страна
+    country_name: Имя
     country_names:
       CA:
       FRA:
       ITA:
       US:
-    coupon: "Купон"
-    coupon_code: "Код купона"
-    coupon_code_already_applied: "Скидочный купон уже был применен к этому заказу"
-    coupon_code_applied: "Купон успешно применен к Вашему заказу."
-    coupon_code_better_exists: "Предыдущий купон выгоднее"
-    coupon_code_expired: "Код купона истек"
-    coupon_code_max_usage: "Лимит использования кода купона превышен"
-    coupon_code_not_eligible: "Это скидочный купон не отвечает требованиям для этого заказа"
-    coupon_code_not_found: "Скидочный купон не существует. Пожалуйста, попробуйте еще раз."
+    coupon: Купон
+    coupon_code: Код купона
+    coupon_code_already_applied: Скидочный купон уже был применен к этому заказу
+    coupon_code_applied: Купон успешно применен к Вашему заказу.
+    coupon_code_better_exists: Предыдущий купон выгоднее
+    coupon_code_expired: Код купона истек
+    coupon_code_max_usage: Лимит использования кода купона превышен
+    coupon_code_not_eligible: Это скидочный купон не отвечает требованиям для этого заказа
+    coupon_code_not_found: Скидочный купон не существует. Пожалуйста, попробуйте еще раз.
     coupon_code_unknown_error:
-    create: "Создать"
-    create_a_new_account: "Создать новую учетную запись"
-    create_new_order: "Создать новый заказ"
+    create: Создать
+    create_a_new_account: Создать новую учетную запись
+    create_new_order: Создать новый заказ
     create_reimbursement:
-    created_at: "Создано в"
-    credit: "Кредит"
-    credit_card: "Кредитная карта"
-    credit_cards: "Кредитные карты"
-    credit_owed: "Кредитная задолженность"
+    created_at: Создано в
+    credit: Кредит
+    credit_card: Кредитная карта
+    credit_cards: Кредитные карты
+    credit_owed: Кредитная задолженность
     credits:
-    currency: "Валюта"
-    currency_decimal_mark: "Десятичный знак валюты"
-    currency_settings: "Настройки валюты"
-    currency_symbol_position: "Положение символа валюты относительно суммы"
-    currency_thousands_separator: "Разделитель тысяч валюты"
-    current: "Текущий"
-    current_promotion_usage: "Использовано: %{count}"
-    customer: "Клиент"
-    customer_details: "Реквизиты клиента"
-    customer_details_updated: "Данные клиента были обновлены."
+    currency: Валюта
+    currency_decimal_mark: Десятичный знак валюты
+    currency_settings: Настройки валюты
+    currency_symbol_position: Положение символа валюты относительно суммы
+    currency_thousands_separator: Разделитель тысяч валюты
+    current: Текущий
+    current_promotion_usage: 'Использовано: %{count}'
+    customer: Клиент
+    customer_details: Реквизиты клиента
+    customer_details_updated: Данные клиента были обновлены.
     customer_return:
-    customer_returns: "Возвраты покупателю"
-    customer_search: "Поиск клиента"
+    customer_returns: Возвраты покупателю
+    customer_search: Поиск клиента
     cut:
     cvv_response:
     dash:
@@ -617,39 +806,39 @@ ru:
         app_id: ID приложения
         app_token: Token приложения
         currently_unavailable: Jirafe недоступен. Spree автоматически подключится к Jirafe снова, когда он будет доступен.
-        explanation: "Эти поля могут быть заполнены, если вы зарегистрируетесь в Jirafe из панели администрирования."
-        header: "Настройки Аналитики Jirafe"
+        explanation: Эти поля могут быть заполнены, если вы зарегистрируетесь в Jirafe из панели администрирования.
+        header: Настройки Аналитики Jirafe
         site_id: ID сайта
-        token: "Токен"
-      jirafe_settings_updated: "Настройки Jirafe обновлены."
-    date: "Дата"
-    date_completed: "Дата завершения"
+        token: Токен
+      jirafe_settings_updated: Настройки Jirafe обновлены.
+    date: Дата
+    date_completed: Дата завершения
     date_picker:
       first_day: 1
       format: "%d.%m.%Y"
       js_format: dd.mm.yy
-    date_range: "Период времени"
-    default: "По умолчанию"
+    date_range: Период времени
+    default: По умолчанию
     default_refund_amount:
-    default_tax: "Стандартный налог"
-    default_tax_zone: "Стандартный налоговый регион"
-    delete: "Удалить"
+    default_tax: Стандартный налог
+    default_tax_zone: Стандартный налоговый регион
+    delete: Удалить
     deleted_variants_present:
-    delivery: "Доставка"
-    depth: "Глубина"
-    description: "Описание"
-    destination: "Назначение"
-    destroy: "Удалить"
-    details: "Описание товара"
-    discount_amount: "Сумма скидки"
-    dismiss_banner: "Нет, спасибо! Я не заинтересован. Не показывайте мне больше это сообщение."
-    display: "Показать"
-    display_currency: "Показывать валюту"
+    delivery: Доставка
+    depth: Глубина
+    description: Описание
+    destination: Назначение
+    destroy: Удалить
+    details: Описание товара
+    discount_amount: Сумма скидки
+    dismiss_banner: Нет, спасибо! Я не заинтересован. Не показывайте мне больше это сообщение.
+    display: Показать
+    display_currency: Показывать валюту
     doesnt_track_inventory:
-    edit: "Редактировать"
+    edit: Редактировать
     editing_resource:
     editing_rma_reason:
-    editing_user: "Редактирование пользователя"
+    editing_user: Редактирование пользователя
     eligibility_errors:
       messages:
         has_excluded_product:
@@ -665,395 +854,403 @@ ru:
         no_user_or_email_specified:
         no_user_specified:
         not_first_order:
-    email: "Электронная почта"
-    empty: "пусто"
-    empty_cart: "Очистить корзину"
-    enable_mail_delivery: "Включить доставку почты"
-    end: "Конец"
-    ending_in: "Оканчивается"
-    environment: "Среда окружения"
-    error: "ошибка"
+    email: Электронная почта
+    empty: пусто
+    empty_cart: Очистить корзину
+    enable_mail_delivery: Включить доставку почты
+    end: Конец
+    ending_in: Оканчивается
+    environment: Среда окружения
+    error: ошибка
     errors:
       messages:
-        could_not_create_taxon: "Невозможно создать таксон"
-        no_payment_methods_available: "Для этого окружения не настроено ни одного способа оплаты"
-        no_shipping_methods_available: "Для указанного местоположения отсутствуют способы доставки, пожалуйста, смените адрес и попробуйте снова."
+        could_not_create_taxon: Невозможно создать таксон
+        no_payment_methods_available: Для этого окружения не настроено ни одного способа оплаты
+        no_shipping_methods_available: Для указанного местоположения отсутствуют способы доставки, пожалуйста, смените адрес и попробуйте снова.
     errors_prohibited_this_record_from_being_saved:
       few: "%{count} ошибки не позволяют сохранить запись в базе"
       many: "%{count} ошибок не позволяют сохранить запись в базе"
-      one: "Одна ошибка не позволяет сохранить запись в базе"
+      one: Одна ошибка не позволяет сохранить запись в базе
       other: "%{count} ошибки не позволяют сохранить запись в базе"
-    event: "Событие"
+    event: Событие
     events:
       spree:
         cart:
-          add: "Добавление в корзину"
+          add: Добавление в корзину
         checkout:
-          coupon_code_added: "Добавлен купон"
+          coupon_code_added: Добавлен купон
         content:
-          visited: "Посещение статической страницы"
+          visited: Посещение статической страницы
         order:
-          contents_changed: "Содержимое заказа изменилось"
-        page_view: "Просмотр статической страницы"
+          contents_changed: Содержимое заказа изменилось
+        page_view: Просмотр статической страницы
         user:
-          signup: "Новый пользователь"
+          signup: Новый пользователь
     exceptions:
-      count_on_hand_setter: "Невозможно установить значение count_on_hand вручную, т.к. оно устанавливается автоматически с помощью recalculate_count_on_hand callback'а. Вместо этого, используйте `update_column(:count_on_hand, value)`"
+      count_on_hand_setter: Невозможно установить значение count_on_hand вручную, т.к. оно устанавливается автоматически с помощью recalculate_count_on_hand callback'а. Вместо этого, используйте `update_column(:count_on_hand, value)`
     exchange_for:
-    excl: "искл."
+    excl: искл.
     existing_shipments:
     expedited_exchanges_warning:
-    expiration: "Окончание действия"
-    extension: "Расширение"
+    expiration: Окончание действия
+    extension: Расширение
     failed_payment_attempts:
-    filename: "Имя файла"
-    fill_in_customer_info: "Заполните информацию о клиенте"
-    filter: "Фильтр"
-    filter_results: "Результаты фильтрации"
-    finalize: "Завершить"
+    filename: Имя файла
+    fill_in_customer_info: Заполните информацию о клиенте
+    filter: Фильтр
+    filter_results: Результаты фильтрации
+    finalize: Завершить
     finalized:
-    find_a_taxon: "Найти таксон"
-    first_item: "Начальная ставка"
-    first_name: "Имя"
-    first_name_begins_with: "Имя начинается с"
-    flat_percent: "Фиксированный процент"
-    flat_rate_per_order: "Фиксированная ставка (за заказ)"
-    flexible_rate: "Гибкая ставка"
-    forgot_password: "Забыли пароль?"
-    free_shipping: "Бесплатная доставка"
+    find_a_taxon: Найти таксон
+    first_item: Начальная ставка
+    first_name: Имя
+    first_name_begins_with: Имя начинается с
+    flat_percent: Фиксированный процент
+    flat_rate_per_order: Фиксированная ставка (за заказ)
+    flexible_rate: Гибкая ставка
+    forgot_password: Забыли пароль?
+    free_shipping: Бесплатная доставка
     free_shipping_amount:
-    front_end: "в публичном интерфейсе"
-    gateway: "Платежный шлюз"
-    gateway_config_unavailable: "Шлюз не доступен для данного окружения"
-    gateway_error: "Ошибка платежного шлюза"
-    general: "Основные"
-    general_settings: "Общие настройки"
+    front_end: в публичном интерфейсе
+    gateway: Платежный шлюз
+    gateway_config_unavailable: Шлюз не доступен для данного окружения
+    gateway_error: Ошибка платежного шлюза
+    general: Основные
+    general_settings: Общие настройки
     google_analytics: Google Analytics
     google_analytics_id: Google Analytics ID
-    guest_checkout: "Гостевой заказ"
-    guest_user_account: "Оформить покупку как гость"
-    has_no_shipped_units: "не имеет отправленных единиц учёта"
-    height: "Высота"
-    hide_cents: "Скрыть центы"
-    home: "Домой"
+    guest_checkout: Гостевой заказ
+    guest_user_account: Оформить покупку как гость
+    has_no_shipped_units: не имеет отправленных единиц учёта
+    height: Высота
+    hide_cents: Скрыть центы
+    home: Домой
     i18n:
-      available_locales: "Доступные переводы"
-      language: "Язык"
-      localization_settings: "Настройки локализации"
+      available_locales: Доступные переводы
+      language: Язык
+      localization_settings: Настройки локализации
       this_file_language: Russian
-    icon: "Иконка"
+    icon: Иконка
     identifier:
-    image: "Изображение"
-    images: "Изображения"
+    image: Изображение
+    images: Изображения
     implement_eligible_for_return:
     implement_requires_manual_intervention:
     inactive:
-    incl: "вкл."
-    included_in_price: "Включено в цену"
-    included_price_validation: "не может быть выбрано, если только вы настроили зону налогообложения по умолчанию"
+    incl: вкл.
+    included_in_price: Включено в цену
+    included_price_validation: не может быть выбрано, если только вы настроили зону налогообложения по умолчанию
     incomplete:
     info_number_of_skus_not_shown:
     info_product_has_multiple_skus:
-    instructions_to_reset_password: "Чтобы сбросить пароль, заполните форму ниже. Новый пароль будет отправлен вам по указанному email"
-    insufficient_stock: "Недостаточно единиц товара, только %{on_hand} есть в наличии"
+    instructions_to_reset_password: Чтобы сбросить пароль, заполните форму ниже. Новый пароль будет отправлен вам по указанному email
+    insufficient_stock: Недостаточно единиц товара, только %{on_hand} есть в наличии
     insufficient_stock_lines_present:
-    intercept_email_address: "Перехват писем"
-    intercept_email_instructions: "Заменить email получателя на этот адрес."
-    internal_name: "Внутреннее имя"
+    intercept_email_address: Перехват писем
+    intercept_email_instructions: Заменить email получателя на этот адрес.
+    internal_name: Внутреннее имя
     invalid_credit_card:
     invalid_exchange_variant:
-    invalid_payment_provider: "Неверно указан способ оплаты"
-    invalid_promotion_action: "Неверная промо-акция"
-    invalid_promotion_rule: "Неверно указан принцип рекламной кампании"
-    inventory: "Товарная номенклатура"
-    inventory_adjustment: "Корректировки"
-    inventory_error_flash_for_insufficient_quantity: "Один из товаров вашей корзины стал недоступен."
+    invalid_payment_provider: Неверно указан способ оплаты
+    invalid_promotion_action: Неверная промо-акция
+    invalid_promotion_rule: Неверно указан принцип рекламной кампании
+    inventory: Товарная номенклатура
+    inventory_adjustment: Корректировки
+    inventory_error_flash_for_insufficient_quantity: Один из товаров вашей корзины стал недоступен.
     inventory_state:
-    is_not_available_to_shipment_address: "не может быть применён к указанному адресу доставки"
-    iso_name: "Имя согласно ISO"
-    item: "Наименование"
-    item_description: "Описание товара"
-    item_total: "Итого (товары)"
+    is_not_available_to_shipment_address: не может быть применён к указанному адресу доставки
+    iso_name: Имя согласно ISO
+    item: Наименование
+    item_description: Описание товара
+    item_total: Итого (товары)
     item_total_rule:
       operators:
-        gt: "больше"
-        gte: "больше или равно"
+        gt: больше
+        gte: больше или равно
         lt:
         lte:
-    items_cannot_be_shipped: "К сожалению мы не можем доставить ваш товар на указанный адрес. Пожалуйста введите другой адрес."
+    items_cannot_be_shipped: К сожалению мы не можем доставить ваш товар на указанный адрес. Пожалуйста введите другой адрес.
     items_in_rmas:
     items_reimbursed:
     items_to_be_reimbursed:
     jirafe: Jirafe
     landing_page_rule:
-      path: "Путь"
-    last_name: "Фамилия"
-    last_name_begins_with: "Фамилия начинается с"
-    learn_more: "Узнать больше"
-    lifetime_stats: "Статистика"
-    line_item_adjustments: "Корректировки позиций"
-    list: "Список"
-    loading: "Загружается"
-    locale_changed: "Язык изменён"
-    location: "Местоположение"
+      path: Путь
+    last_name: Фамилия
+    last_name_begins_with: Фамилия начинается с
+    learn_more: Узнать больше
+    lifetime_stats: Статистика
+    line_item_adjustments: Корректировки позиций
+    list: Список
+    loading: Загружается
+    locale_changed: Язык изменён
+    location: Местоположение
     lock: Lock
     log_entries:
-    logged_in_as: "Пользователь"
-    logged_in_succesfully: "Вы вошли в систему"
-    logged_out: "Вы вышли из системы."
-    login: "Логин"
-    login_as_existing: "Войти как покупатель"
-    login_failed: "Вход не выполнен."
-    login_name: "Логин"
-    logout: "Выйти"
-    logs: "Журналы событий"
-    look_for_similar_items: "Посмотрите похожие товары"
-    make_refund: "Сделать возврат"
+    logged_in_as: Пользователь
+    logged_in_succesfully: Вы вошли в систему
+    logged_out: Вы вышли из системы.
+    login: Логин
+    login_as_existing: Войти как покупатель
+    login_failed: Вход не выполнен.
+    login_name: Логин
+    logout: Выйти
+    logs: Журналы событий
+    look_for_similar_items: Посмотрите похожие товары
+    make_refund: Сделать возврат
     make_sure_the_above_reimbursement_amount_is_correct:
     manage_promotion_categories:
     manage_variants:
     manual_intervention_required:
-    master_price: "Основная цена"
+    master_price: Основная цена
     match_choices:
-      all: "Всем"
-      none: "Ни одному"
-    max_items: "Максимальное число наименований по начальной ставке"
-    member_since: "Зарегистр. с"
+      all: Всем
+      none: Ни одному
+    max_items: Максимальное число наименований по начальной ставке
+    member_since: Зарегистр. с
     memo:
-    meta_description: "Описание"
-    meta_keywords: "Ключевые слова"
+    meta_description: Описание
+    meta_keywords: Ключевые слова
     meta_title:
-    metadata: "Метаданные"
-    minimal_amount: "Минимальная сумма"
-    month: "Месяц"
-    more: "Больше"
-    move_stock_between_locations: "Перемещение товаров между складами"
-    my_account: "Моя учетная запись"
-    my_orders: "Мои заказы"
-    name: "Наименование"
+    metadata: Метаданные
+    minimal_amount: Минимальная сумма
+    month: Месяц
+    more: Больше
+    move_stock_between_locations: Перемещение товаров между складами
+    my_account: Моя учетная запись
+    my_orders: Мои заказы
+    name: Наименование
     name_on_card:
-    name_or_sku: "Наименование или артикул"
-    new: "Новый"
-    new_adjustment: "Новая корректировка"
-    new_country: "Новая страна"
-    new_customer: "Для новых пользователей"
-    new_customer_return: "Новый возврат покупателю"
-    new_image: "Новое изображение"
-    new_option_type: "Новая опция"
-    new_order: "Новый заказ"
-    new_order_completed: "Оформление заказа завершено"
-    new_payment: "Новый платёж"
-    new_payment_method: "Новый способ оплаты"
-    new_product: "Новый товар"
-    new_promotion: "Новая акция"
-    new_promotion_category: "Новая категория акций"
-    new_property: "Новое свойство"
-    new_prototype: "Новый прототип"
+    name_or_sku: Наименование или артикул
+    new: Новый
+    new_adjustment: Новая корректировка
+    new_country: Новая страна
+    new_customer: Для новых пользователей
+    new_customer_return: Новый возврат покупателю
+    new_image: Новое изображение
+    new_option_type: Новая опция
+    new_order: Новый заказ
+    new_order_completed: Оформление заказа завершено
+    new_payment: Новый платёж
+    new_payment_method: Новый способ оплаты
+    new_product: Новый товар
+    new_promotion: Новая акция
+    new_promotion_category: Новая категория акций
+    new_property: Новое свойство
+    new_prototype: Новый прототип
     new_refund:
-    new_refund_reason: "Новая причина возврата"
-    new_return_authorization: "Новое разрешение на возврат"
-    new_rma_reason: "Новая причина разрешения на возврат"
+    new_refund_reason: Новая причина возврата
+    new_return_authorization: Новое разрешение на возврат
+    new_rma_reason: Новая причина разрешения на возврат
     new_shipment_at_location:
-    new_shipping_category: "Новая категория доставки"
-    new_shipping_method: "Новый способ доставки"
-    new_state: "Новый регион/область"
-    new_stock_location: "Добавить новый склад"
-    new_stock_movement: "Новое движение товара"
-    new_stock_transfer: "Новое перемещение по складу"
-    new_tax_category: "Новая категория налогов"
-    new_tax_rate: "Новая ставка налога"
-    new_taxon: "Новый таксон"
-    new_taxonomy: "Новая таксономия"
-    new_tracker: "Новый трекер"
-    new_user: "Новый пользователь"
-    new_variant: "Новый вариант"
-    new_zone: "Новая зона"
-    next: "след."
-    no_actions_added: "Нет действий"
+    new_shipping_category: Новая категория доставки
+    new_shipping_method: Новый способ доставки
+    new_state: Новый регион/область
+    new_stock_location: Добавить новый склад
+    new_stock_movement: Новое движение товара
+    new_stock_transfer: Новое перемещение по складу
+    new_tax_category: Новая категория налогов
+    new_tax_rate: Новая ставка налога
+    new_taxon: Новый таксон
+    new_taxonomy: Новая таксономия
+    new_tracker: Новый трекер
+    new_user: Новый пользователь
+    new_variant: Новый вариант
+    new_zone: Новая зона
+    next: след.
+    no_actions_added: Нет действий
     no_payment_found:
-    no_pending_payments: "Нет незавершённых платежей"
-    no_products_found: "Не найдено ни одного товара"
+    no_pending_payments: Нет незавершённых платежей
+    no_products_found: Не найдено ни одного товара
     no_resource_found: "%{resource} не найдены"
-    no_results: "Ничего не найдено"
+    no_results: Ничего не найдено
     no_returns_found:
-    no_rules_added: "Ни одного правила не задано"
+    no_rules_added: Ни одного правила не задано
     no_shipping_method_selected:
     no_state_changes:
-    no_tracking_present: "Отсутствуют детали отслеживания"
-    none: "Ни одного"
+    no_tracking_present: Отсутствуют детали отслеживания
+    none: Ни одного
     none_selected:
-    normal_amount: "Обычная сумма"
-    not: "не"
-    not_available: "Не доступен"
-    not_enough_stock: "Недостаточно позиций в исходном местоположении для завершения движения"
+    normal_amount: Обычная сумма
+    not: не
+    not_available: Не доступен
+    not_enough_stock: Недостаточно позиций в исходном местоположении для завершения движения
     not_found: "%{resource} не найден"
     note:
     notice_messages:
-      product_cloned: "Копия товара создана"
-      product_deleted: "Товар успешно удалён"
-      product_not_cloned: "Товар не может быть клонирован"
-      product_not_deleted: "Товар не может быть удалён"
-      variant_deleted: "Вариант успешно удалён"
-      variant_not_deleted: "Вариант не может быть удален"
-    num_orders: "Кол-во заказов"
-    on_hand: "В наличии"
-    open: "Открыть"
-    open_all_adjustments: "Открыть все корректировки"
-    option_type: "Товарная опция"
-    option_type_placeholder: "Выберите тип опции"
-    option_types: "Товарные опции"
-    option_value: "Возможное значение опции"
-    option_values: "Возможные значения опции"
-    optional: "Не обязательно"
-    options: "Опции"
-    or: "или"
-    or_over_price: "более чем %{price}"
-    order: "Заказ"
-    order_adjustments: "Корректировки заказа"
+      product_cloned: Копия товара создана
+      product_deleted: Товар успешно удалён
+      product_not_cloned: Товар не может быть клонирован
+      product_not_deleted: Товар не может быть удалён
+      variant_deleted: Вариант успешно удалён
+      variant_not_deleted: Вариант не может быть удален
+    num_orders: Кол-во заказов
+    on_hand: В наличии
+    open: Открыть
+    open_all_adjustments: Открыть все корректировки
+    option_type: Товарная опция
+    option_type_placeholder: Выберите тип опции
+    option_types: Товарные опции
+    option_value: Возможное значение опции
+    option_values: Возможные значения опции
+    optional: Не обязательно
+    options: Опции
+    or: или
+    or_over_price: более чем %{price}
+    order: Заказ
+    order_adjustments: Корректировки заказа
     order_already_updated:
-    order_approved: "Заказ подтвержден"
+    order_approved: Заказ подтвержден
     order_canceled:
-    order_details: "Реквизиты заказа"
-    order_email_resent: "Письмо с описанием заказа выслано повторно"
-    order_information: "Информация"
+    order_details: Реквизиты заказа
+    order_email_resent: Письмо с описанием заказа выслано повторно
+    order_information: Информация
     order_mailer:
       cancel_email:
-        dear_customer: "Дорогой покупатель,\n"
-        instructions: "Ваш заказ был отменен. Сохраните эту информацию для истории."
-        order_summary_canceled: "Детали заказа [ОТМЕНЕНО]"
-        subject: "Аннулирование заказа"
+        dear_customer: 'Дорогой покупатель,
+
+'
+        instructions: Ваш заказ был отменен. Сохраните эту информацию для истории.
+        order_summary_canceled: Детали заказа [ОТМЕНЕНО]
+        subject: Аннулирование заказа
         subtotal:
         total:
       confirm_email:
-        dear_customer: "Дорогой покупатель,\n"
-        instructions: "Пожалуйста, проверьте детали заказа."
-        order_summary: "Детали заказа"
-        subject: "Подтверждение заказа"
+        dear_customer: 'Дорогой покупатель,
+
+'
+        instructions: Пожалуйста, проверьте детали заказа.
+        order_summary: Детали заказа
+        subject: Подтверждение заказа
         subtotal:
-        thanks: "Спасибо, что выбрали нас."
+        thanks: Спасибо, что выбрали нас.
         total:
-    order_not_found: "Мы не смогли найти Ваш заказ. Попробуйте еще раз."
-    order_number: "Заказ %{number}"
-    order_processed_successfully: "Ваш заказ был успешно обработан"
+      inventory_cancellation:
+        dear_customer: 'Дорогой покупатель,
+
+'
+    order_not_found: Мы не смогли найти Ваш заказ. Попробуйте еще раз.
+    order_number: Заказ %{number}
+    order_processed_successfully: Ваш заказ был успешно обработан
     order_resumed:
     order_state:
-      address: "Адрес"
-      awaiting_return: "Ожидает возврата"
-      canceled: "Отменён"
-      cart: "Корзина"
-      complete: "Завершение"
-      confirm: "Подтверждение"
+      address: Адрес
+      awaiting_return: Ожидает возврата
+      canceled: Отменён
+      cart: Корзина
+      complete: Завершение
+      confirm: Подтверждение
       considered_risky:
-      delivery: "Доставка"
-      payment: "Оплата"
-      resumed: "Возобновлён"
-      returned: "Возвращён"
-    order_summary: "Сводка по заказу"
-    order_sure_want_to: "Вы уверены, что хотите %{event} этот заказ?"
-    order_total: "Итого заказ"
-    order_updated: "Заказ обновлен"
-    orders: "Заказы"
+      delivery: Доставка
+      payment: Оплата
+      resumed: Возобновлён
+      returned: Возвращён
+    order_summary: Сводка по заказу
+    order_sure_want_to: Вы уверены, что хотите %{event} этот заказ?
+    order_total: Итого заказ
+    order_updated: Заказ обновлен
+    orders: Заказы
     other_items_in_other:
-    out_of_stock: "Нет в наличии"
-    overview: "Обзор"
-    package_from: "Фасовку в"
+    out_of_stock: Нет в наличии
+    overview: Обзор
+    package_from: Фасовку в
     pagination:
-      next_page: "следующая страница »"
+      next_page: следующая страница »
       previous_page: "« предыдущая страница"
       truncate: "…"
-    password: "Пароль"
+    password: Пароль
     paste: Paste
-    path: "Путь"
-    pay: "оплатить"
-    payment: "Платеж"
+    path: Путь
+    pay: оплатить
+    payment: Платеж
     payment_could_not_be_created:
     payment_identifier:
-    payment_information: "Информация о платеже"
-    payment_method: "Способ оплаты"
-    payment_method_not_supported: "Этот способ оплаты не поддерживается"
-    payment_methods: "Способы оплаты"
-    payment_processing_failed: "Невозможно произвести платёж, пожалуйста, проверьте введённую информацию"
-    payment_processor_choose_banner_text: "Если Вам нужна помощь в выборе способа оплаты, пожалуйста, зайдите на"
-    payment_processor_choose_link: "наша страница оплаты"
-    payment_state: "Статус платежа"
+    payment_information: Информация о платеже
+    payment_method: Способ оплаты
+    payment_method_not_supported: Этот способ оплаты не поддерживается
+    payment_methods: Способы оплаты
+    payment_processing_failed: Невозможно произвести платёж, пожалуйста, проверьте введённую информацию
+    payment_processor_choose_banner_text: Если Вам нужна помощь в выборе способа оплаты, пожалуйста, зайдите на
+    payment_processor_choose_link: наша страница оплаты
+    payment_state: Статус платежа
     payment_states:
-      balance_due: "частично"
-      checkout: "оформляется"
-      completed: "завершен"
-      credit_owed: "в кредит"
-      failed: "ошибка"
-      paid: "оплачен"
-      pending: "в ожидании"
-      processing: "в обработке"
-      void: "аннулирован"
-    payment_updated: "Платёж обновлён"
-    payments: "Платежи"
+      balance_due: частично
+      checkout: оформляется
+      completed: завершен
+      credit_owed: в кредит
+      failed: ошибка
+      paid: оплачен
+      pending: в ожидании
+      processing: в обработке
+      void: аннулирован
+    payment_updated: Платёж обновлён
+    payments: Платежи
     pending:
-    percent: "Процент"
-    percent_per_item: "Процент с каждой единицы товара"
-    permalink: "Постоянная ссылка"
-    phone: "Телефон"
-    place_order: "Разместить заказ"
-    please_define_payment_methods: "Сначала определите способ оплаты."
-    populate_get_error: "Что-то пошло не так. Попробуйте добавить товар еще раз."
-    powered_by: "Работает на"
+    percent: Процент
+    percent_per_item: Процент с каждой единицы товара
+    permalink: Постоянная ссылка
+    phone: Телефон
+    place_order: Разместить заказ
+    please_define_payment_methods: Сначала определите способ оплаты.
+    populate_get_error: Что-то пошло не так. Попробуйте добавить товар еще раз.
+    powered_by: Работает на
     pre_tax_amount:
     pre_tax_refund_amount:
     pre_tax_total:
     preferred_reimbursement_type:
-    presentation: "Отображать как"
-    previous: "пред."
+    presentation: Отображать как
+    previous: пред.
     previous_state_missing:
-    price: "Цена"
-    price_range: "Ценовой диапазон"
+    price: Цена
+    price_range: Ценовой диапазон
     price_sack: Price Sack
-    process: "Обработать"
-    product: "Товар"
-    product_details: "Описание товара"
-    product_has_no_description: "У данного товара нет описания."
-    product_not_available_in_this_currency: "Этот товар недоступен в выбранной валюте."
-    product_properties: "Свойства товара"
+    process: Обработать
+    product: Товар
+    product_details: Описание товара
+    product_has_no_description: У данного товара нет описания.
+    product_not_available_in_this_currency: Этот товар недоступен в выбранной валюте.
+    product_properties: Свойства товара
     product_rule:
-      choose_products: "Выбранные товары"
+      choose_products: Выбранные товары
       label:
-      match_all: "все"
-      match_any: "хотя бы один"
+      match_all: все
+      match_any: хотя бы один
       match_none:
       product_source:
-        group: "Из группы товаров"
-        manual: "Выбрать вручную"
-    products: "Товары"
-    promotion: "Промо-акция"
-    promotion_action: "Промо-акция"
+        group: Из группы товаров
+        manual: Выбрать вручную
+    products: Товары
+    promotion: Промо-акция
+    promotion_action: Промо-акция
     promotion_action_types:
       create_adjustment:
-        description: "Создаёт промо-корректировки для заказа"
-        name: "Создать корректировку"
+        description: Создаёт промо-корректировки для заказа
+        name: Создать корректировку
       create_item_adjustments:
         description:
         name:
       create_line_items:
-        description: "Заполняет корзину указанным количеством вариантов"
-        name: "Создать элемент заказа"
+        description: Заполняет корзину указанным количеством вариантов
+        name: Создать элемент заказа
       free_shipping:
         description:
         name:
-    promotion_actions: "Акции"
+    promotion_actions: Акции
     promotion_form:
       match_policies:
-        all: "Соответствует всем этим правилам"
-        any: "Соответствует хотя бы одному правилу"
-    promotion_rule: "Правило"
+        all: Соответствует всем этим правилам
+        any: Соответствует хотя бы одному правилу
+    promotion_rule: Правило
     promotion_rule_types:
       first_order:
-        description: "Должен быть первым заказом покупателя"
-        name: "Первый заказ"
+        description: Должен быть первым заказом покупателя
+        name: Первый заказ
       item_total:
-        description: "Сумма заказа соответствует следующим критериям"
-        name: "Сумма заказа"
+        description: Сумма заказа соответствует следующим критериям
+        name: Сумма заказа
       landing_page:
-        description: "Покупатель должен был попасть на указанную страницу"
-        name: "Страница"
+        description: Покупатель должен был попасть на указанную страницу
+        name: Страница
       one_use_per_user:
         description:
         name:
@@ -1061,46 +1258,46 @@ ru:
         description:
         name:
       product:
-        description: "Заказ включает указанные товары"
-        name: "Товары"
+        description: Заказ включает указанные товары
+        name: Товары
       taxon:
         description:
         name:
       user:
-        description: "Доступно только для указанных пользователей"
-        name: "Пользователи"
+        description: Доступно только для указанных пользователей
+        name: Пользователи
       user_logged_in:
-        description: "Доступно только зарегистрированным пользователям"
-        name: "Пользователь авторизовался"
+        description: Доступно только зарегистрированным пользователям
+        name: Пользователь авторизовался
     promotion_uses:
     promotionable:
-    promotions: "Промо-акции"
-    propagate_all_variants: "Применить ко всем вариантам"
-    properties: "Свойства"
-    property: "Свойство"
-    prototype: "Прототип"
-    prototypes: "Прототипы"
-    provider: "Провайдер"
-    provider_settings_warning: "Если вы меняете провайдера, вы должны сохранить это изменение, прежде чем вы сможете изменить настройки провайдера."
-    qty: "Кол-во"
-    quantity: "Количество"
-    quantity_returned: "Количество возврата"
-    quantity_shipped: "Отправленное количество"
-    quick_search: "Поиск . . ."
-    rate: "Ставка"
-    reason: "Причина"
-    receive: "Получить"
-    receive_stock: "Получить товар"
-    received: "Получен"
+    promotions: Промо-акции
+    propagate_all_variants: Применить ко всем вариантам
+    properties: Свойства
+    property: Свойство
+    prototype: Прототип
+    prototypes: Прототипы
+    provider: Провайдер
+    provider_settings_warning: Если вы меняете провайдера, вы должны сохранить это изменение, прежде чем вы сможете изменить настройки провайдера.
+    qty: Кол-во
+    quantity: Количество
+    quantity_returned: Количество возврата
+    quantity_shipped: Отправленное количество
+    quick_search: Поиск . . .
+    rate: Ставка
+    reason: Причина
+    receive: Получить
+    receive_stock: Получить товар
+    received: Получен
     reception_status:
-    reference: "Ссылка"
-    refund: "Возврат"
+    reference: Ссылка
+    refund: Возврат
     refund_amount_must_be_greater_than_zero:
-    refund_reasons: "Причины возврата"
+    refund_reasons: Причины возврата
     refunded_amount:
     refunds:
-    register: "Зарегистрироваться как новый пользователь"
-    registration: "Регистрация"
+    register: Зарегистрироваться как новый пользователь
+    registration: Регистрация
     reimburse:
     reimbursed:
     reimbursement:
@@ -1118,128 +1315,130 @@ ru:
     reimbursement_status:
     reimbursement_type:
     reimbursement_type_override:
-    reimbursement_types: "Типы возврата"
+    reimbursement_types: Типы возврата
     reimbursements:
     reject:
     rejected:
-    remember_me: "Запомнить меня"
-    remove: "Убрать"
-    rename: "Переименовать"
+    remember_me: Запомнить меня
+    remove: Убрать
+    rename: Переименовать
     report:
-    reports: "Отчеты"
-    resend: "Отправить повторно"
-    reset_password: "Сбросить мой пароль"
-    response_code: "Код ответа"
-    resume: "возобновить"
-    resumed: "Возобновлен"
-    return: "возвратить"
-    return_authorization: "Разрешение на возврат"
-    return_authorization_reasons: "Причины разрешения на возврат"
-    return_authorization_updated: "Разрешение на возврат обновлено"
-    return_authorizations: "Разрешения на возврат"
+    reports: Отчеты
+    resend: Отправить повторно
+    reset_password: Сбросить мой пароль
+    response_code: Код ответа
+    resume: возобновить
+    resumed: Возобновлен
+    return: возвратить
+    return_authorization: Разрешение на возврат
+    return_authorization_reasons: Причины разрешения на возврат
+    return_authorization_updated: Разрешение на возврат обновлено
+    return_authorizations: Разрешения на возврат
     return_item_inventory_unit_ineligible:
     return_item_inventory_unit_reimbursed:
     return_item_rma_ineligible:
     return_item_time_period_ineligible:
     return_items:
     return_items_cannot_be_associated_with_multiple_orders:
-    return_number: "Номер возврата"
-    return_quantity: "возвращенное количество"
-    returned: "Возвращенные"
-    returns: "Разрешения на возврат"
-    review: "Проверить"
+    return_number: Номер возврата
+    return_quantity: возвращенное количество
+    returned: Возвращенные
+    returns: Разрешения на возврат
+    review: Проверить
     risk:
     risk_analysis:
     risky:
     rma_credit: RMA Credit
-    rma_number: "Номер RMA"
-    rma_value: "Сумма RMA"
-    roles: "Роли"
-    rules: "Правила"
-    safe: "Безопасный"
-    sales_total: "Итого (продажи)"
-    sales_total_description: "Общий объём продаж по всем заказам"
-    sales_totals: "Всего продано"
-    save_and_continue: "Сохранить и продолжить"
-    save_my_address: "Сохранить адрес"
-    say_no: "Нет"
-    say_yes: "Да"
-    scope: "Фильтр"
-    search: "Поиск"
-    search_results: "Результаты поиска по запросу '%{keywords}'"
-    searching: "Идёт поиск..."
-    secure_connection_type: "Тип защищенного соединения"
-    security_settings: "Настройки безопасности"
-    select: "Выбрать"
-    select_a_return_authorization_reason: "Выбрать причину разрешения на возврат"
-    select_a_stock_location: "Выбрать адрес склада"
-    select_from_prototype: "Выбрать из прототипов"
-    select_stock: "Выбрать склад"
-    selected_quantity_not_available: 'товара %{item} недостаточно.'
-    send_copy_of_all_mails_to: "Отсылать копии всех писем на"
-    send_mails_as: "Отсылать почту как"
-    server: "Сервер"
-    server_error: "На сервере произошла ошибка"
-    settings: "Настройки"
-    ship: "доставка"
-    ship_address: "Адрес доставки"
-    ship_total: "Всего к доставке"
-    shipment: "Отправка"
-    shipment_adjustments: "Корректировки доставки"
+    rma_number: Номер RMA
+    rma_value: Сумма RMA
+    roles: Роли
+    rules: Правила
+    safe: Безопасный
+    sales_total: Итого (продажи)
+    sales_total_description: Общий объём продаж по всем заказам
+    sales_totals: Всего продано
+    save_and_continue: Сохранить и продолжить
+    save_my_address: Сохранить адрес
+    say_no: Нет
+    say_yes: Да
+    scope: Фильтр
+    search: Поиск
+    search_results: Результаты поиска по запросу '%{keywords}'
+    searching: Идёт поиск...
+    secure_connection_type: Тип защищенного соединения
+    security_settings: Настройки безопасности
+    select: Выбрать
+    select_a_return_authorization_reason: Выбрать причину разрешения на возврат
+    select_a_stock_location: Выбрать адрес склада
+    select_from_prototype: Выбрать из прототипов
+    select_stock: Выбрать склад
+    selected_quantity_not_available: товара %{item} недостаточно.
+    send_copy_of_all_mails_to: Отсылать копии всех писем на
+    send_mails_as: Отсылать почту как
+    server: Сервер
+    server_error: На сервере произошла ошибка
+    settings: Настройки
+    ship: доставка
+    ship_address: Адрес доставки
+    ship_total: Всего к доставке
+    shipment: Отправка
+    shipment_adjustments: Корректировки доставки
     shipment_details:
     shipment_mailer:
       shipped_email:
-        dear_customer: "Дорогой покупатель,\n"
-        instructions: "Ваш заказ был успешно отправлен."
-        shipment_summary: "Детали доставки"
-        subject: "Уведомление о доставке"
-        thanks: "Спасибо, что выбрали нас."
-        track_information: "Детали отслеживания доставки: %{tracking}"
-        track_link: "Адрес трекинга: %{url}"
-    shipment_state: "Статус отправки"
+        dear_customer: 'Дорогой покупатель,
+
+'
+        instructions: Ваш заказ был успешно отправлен.
+        shipment_summary: Детали доставки
+        subject: Уведомление о доставке
+        thanks: Спасибо, что выбрали нас.
+        track_information: 'Детали отслеживания доставки: %{tracking}'
+        track_link: 'Адрес трекинга: %{url}'
+    shipment_state: Статус отправки
     shipment_states:
-      backorder: "задерживается"
+      backorder: задерживается
       canceled:
-      partial: "частично"
-      pending: "ожидает"
-      ready: "готов"
-      shipped: "отправлен"
+      partial: частично
+      pending: ожидает
+      ready: готов
+      shipped: отправлен
     shipment_transfer_error:
     shipment_transfer_success:
-    shipments: "Отправки"
-    shipped: "Отправлено"
-    shipping: "Доставка"
-    shipping_address: "Адрес доставки"
-    shipping_categories: "Категории доставки"
-    shipping_category: "Категория доставки"
-    shipping_flat_rate_per_item: "Фиксированная ставка за единицу товара"
-    shipping_flat_rate_per_order: "Фиксированная ставка"
-    shipping_flexible_rate: "Гибкая ставка за единицу товара"
-    shipping_instructions: "Иструкции по доставке"
-    shipping_method: "Способ доставки"
-    shipping_methods: "Способы доставки"
-    shipping_price_sack: "Подсчет стоимости доставки"
-    shipping_total: "Итого (доставка)"
+    shipments: Отправки
+    shipped: Отправлено
+    shipping: Доставка
+    shipping_address: Адрес доставки
+    shipping_categories: Категории доставки
+    shipping_category: Категория доставки
+    shipping_flat_rate_per_item: Фиксированная ставка за единицу товара
+    shipping_flat_rate_per_order: Фиксированная ставка
+    shipping_flexible_rate: Гибкая ставка за единицу товара
+    shipping_instructions: Иструкции по доставке
+    shipping_method: Способ доставки
+    shipping_methods: Способы доставки
+    shipping_price_sack: Подсчет стоимости доставки
+    shipping_total: Итого (доставка)
     shop_by_taxonomy: "%{taxonomy}"
-    shopping_cart: "Корзина"
-    show: "Показать"
-    show_active: "Показать активные"
-    show_deleted: "Показать удаленные"
-    show_only_complete_orders: "Показывать только завершённые заказы"
+    shopping_cart: Корзина
+    show: Показать
+    show_active: Показать активные
+    show_deleted: Показать удаленные
+    show_only_complete_orders: Показывать только завершённые заказы
     show_only_considered_risky:
-    show_rate_in_label: "Показывать процент в названии"
-    sku: "Артикул"
+    show_rate_in_label: Показывать процент в названии
+    sku: Артикул
     skus:
-    slug: "Ссылка"
-    source: "Источник"
-    special_instructions: "Дополнительные инструкции"
-    split: "Разделить"
-    spree_gateway_error_flash_for_checkout: "Возникли проблемы с Вашими реквизитами. Пожалуйста, проверьте их и попробуйте ещё раз."
+    slug: Ссылка
+    source: Источник
+    special_instructions: Дополнительные инструкции
+    split: Разделить
+    spree_gateway_error_flash_for_checkout: Возникли проблемы с Вашими реквизитами. Пожалуйста, проверьте их и попробуйте ещё раз.
     ssl:
       change_protocol:
-    start: "Начало"
-    state: "Регион/Область"
-    state_based: "Есть области"
+    start: Начало
+    state: Регион/Область
+    state_based: Есть области
     state_machine_states:
       accepted:
       address:
@@ -1272,130 +1471,154 @@ ru:
       returned:
       shipped:
       void:
-    states: "Регионы/Области"
-    states_required: "Регионы обязательны"
-    status: "Статус"
-    stock: "Управление запасами"
-    stock_location: "Расположение склада"
-    stock_location_info: "Подробности расположения склада"
-    stock_locations: "Адреса складов"
+    states: Регионы/Области
+    states_required: Регионы обязательны
+    status: Статус
+    stock: Управление запасами
+    stock_location: Расположение склада
+    stock_location_info: Подробности расположения склада
+    stock_locations: Адреса складов
     stock_locations_need_a_default_country:
-    stock_management: "Управление запасами"
-    stock_management_requires_a_stock_location: "Добавьте расположение склада для управления запасами."
-    stock_movements: "Перемещения товаров"
-    stock_movements_for_stock_location: "Перемещения товаров для %{stock_location_name}"
-    stock_successfully_transferred: "Товары успешно перемещены с одного склада на другой."
-    stock_transfer: "Движение товаров"
-    stock_transfers: "Движения товаров"
-    stop: "Конец"
-    store: "В магазин"
-    street_address: "Адрес"
-    street_address_2: "Адрес (строка 2)"
-    subtotal: "Подытог"
-    subtract: "Вычет"
+    stock_management: Управление запасами
+    stock_management_requires_a_stock_location: Добавьте расположение склада для управления запасами.
+    stock_movements: Перемещения товаров
+    stock_movements_for_stock_location: Перемещения товаров для %{stock_location_name}
+    stock_successfully_transferred: Товары успешно перемещены с одного склада на другой.
+    stock_transfer: Движение товаров
+    stock_transfers: Движения товаров
+    stop: Конец
+    store: В магазин
+    street_address: Адрес
+    street_address_2: Адрес (строка 2)
+    subtotal: Подытог
+    subtract: Вычет
     success:
     successfully_created: "%{resource} был успешно создан!"
     successfully_refunded:
     successfully_removed: "%{resource} был успешно удален!"
-    successfully_signed_up_for_analytics: "Успешно авторизованы в Spree Analytics"
+    successfully_signed_up_for_analytics: Успешно авторизованы в Spree Analytics
     successfully_updated: "%{resource} был успешно обновлен!"
-    summary: "Сводка"
-    tax: "Налог"
-    tax_categories: "Категории налогов"
-    tax_category: "Категория налогов"
+    summary: Сводка
+    tax: Налог
+    tax_categories: Категории налогов
+    tax_category: Категория налогов
     tax_code:
-    tax_included: "Вкл. налоги"
-    tax_rate_amount_explanation: "Налоговые ставки вводятся как десятичные значения (напр. если налог 5%, то вводите 0.05)"
-    tax_rates: "Налоговые ставки"
-    taxon: "Таксон"
-    taxon_edit: "Редактировать таксон"
-    taxon_placeholder: "Добавить таксон"
+    tax_included: Вкл. налоги
+    tax_rate_amount_explanation: Налоговые ставки вводятся как десятичные значения (напр. если налог 5%, то вводите 0.05)
+    tax_rates: Налоговые ставки
+    taxon: Таксон
+    taxon_edit: Редактировать таксон
+    taxon_placeholder: Добавить таксон
     taxon_rule:
       choose_taxons:
       label:
       match_all:
       match_any:
-    taxonomies: "Таксономии"
-    taxonomy: "Таксономия"
-    taxonomy_edit: "Редактирование таксономии"
-    taxonomy_tree_error: "Запрашиваемое изменение не было осуществленно и дерево возвращено в предыдущее состояние. Пожалуйста, попытайтесь снова."
+    taxonomies: Таксономии
+    taxonomy: Таксономия
+    taxonomy_edit: Редактирование таксономии
+    taxonomy_tree_error: Запрашиваемое изменение не было осуществленно и дерево возвращено в предыдущее состояние. Пожалуйста, попытайтесь снова.
     taxonomy_tree_instruction: "* Щёлкните правой кнопкой мыши на элеменете дерева для добавления, удаления или сортировки таксонов."
-    taxons: "Таксоны"
-    test: "Тест"
+    taxons: Таксоны
+    test: Тест
     test_mailer:
       test_email:
-        greeting: "Поздравляем!"
-        message: "Если Вы читаете это сообщение, значит почтовые настройки Spree верны."
-        subject: "Тестовое сообщение"
-    test_mode: "Тестовый режим"
-    thank_you_for_your_order: "Спасибо за покупку!"
-    there_are_no_items_for_this_order: "В этом заказе нет товаров. Добавьте товары, чтобы продолжить, пожалуйста."
-    there_were_problems_with_the_following_fields: "Возникли некоторые проблемы со следующими полями"
+        greeting: Поздравляем!
+        message: Если Вы читаете это сообщение, значит почтовые настройки Spree верны.
+        subject: Тестовое сообщение
+    test_mode: Тестовый режим
+    thank_you_for_your_order: Спасибо за покупку!
+    there_are_no_items_for_this_order: В этом заказе нет товаров. Добавьте товары, чтобы продолжить, пожалуйста.
+    there_were_problems_with_the_following_fields: Возникли некоторые проблемы со следующими полями
     this_order_has_already_received_a_refund:
-    thumbnail: "Миниатюра"
+    thumbnail: Миниатюра
     tiered_flat_rate:
     tiered_percent:
     tiers:
-    time: "Время"
-    to_add_variants_you_must_first_define: "Перед добавлением вариантов, вы должны определить"
-    total: "Итого"
+    time: Время
+    to_add_variants_you_must_first_define: Перед добавлением вариантов, вы должны определить
+    total: Итого
     total_per_item:
     total_pre_tax_refund:
     total_price:
-    total_sales: "Всего продано на"
-    track_inventory: "Отслеживать наличие"
-    tracking: "Отслеживание"
-    tracking_number: "Трекинговый номер"
-    tracking_url: "Трекинговый URL"
-    tracking_url_placeholder: "например, http://quickship.com/package?num=:tracking"
+    total_sales: Всего продано на
+    track_inventory: Отслеживать наличие
+    tracking: Отслеживание
+    tracking_number: Трекинговый номер
+    tracking_url: Трекинговый URL
+    tracking_url_placeholder: например, http://quickship.com/package?num=:tracking
     transaction_id:
-    transfer_from_location: "Перевести из"
-    transfer_stock: "Перевести Товар"
-    transfer_to_location: "Перевести на"
-    tree: "Дерево"
-    type: "Тип"
-    type_to_search: "Начните печатать чтобы активировать поиск"
-    unable_to_connect_to_gateway: "Не удалось подключиться к платёжному шлюзу."
+    transfer_from_location: Перевести из
+    transfer_stock: Перевести Товар
+    transfer_to_location: Перевести на
+    tree: Дерево
+    type: Тип
+    type_to_search: Начните печатать чтобы активировать поиск
+    unable_to_connect_to_gateway: Не удалось подключиться к платёжному шлюзу.
     unable_to_create_reimbursements:
-    under_price: "Дешевле %{price}"
-    unlock: "Разблокировать"
-    unrecognized_card_type: "Неизвестный тип карты"
-    unshippable_items: "Неотправляемые Товары"
-    update: "Изменить"
-    updating: "Обновление"
-    usage_limit: "Максимальное количество использований"
-    use_app_default: "По умолчанию"
-    use_billing_address: "Использовать платёжный адрес"
-    use_new_cc: "Использовать новую карту"
-    use_s3: "Использовать Amazon S3 для хранения изображений"
-    user: "Пользователь"
+    under_price: Дешевле %{price}
+    unlock: Разблокировать
+    unrecognized_card_type: Неизвестный тип карты
+    unshippable_items: Неотправляемые Товары
+    update: Изменить
+    updating: Обновление
+    usage_limit: Максимальное количество использований
+    use_app_default: По умолчанию
+    use_billing_address: Использовать платёжный адрес
+    use_new_cc: Использовать новую карту
+    use_s3: Использовать Amazon S3 для хранения изображений
+    user: Пользователь
     user_rule:
-      choose_users: "Выбрать пользователей"
-    users: "Пользователи"
+      choose_users: Выбрать пользователей
+    users: Пользователи
     validation:
-      cannot_be_less_than_shipped_units: "не может быть меньше, чем количество отгруженных единиц"
+      cannot_be_less_than_shipped_units: не может быть меньше, чем количество отгруженных единиц
       cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock: "превышает количество на складе. Пожалуйста проверьте количество товара."
-      is_too_large: "слишком много - количество на складе меньше запрошенного количества!"
-      must_be_int: "должно быть целым числом"
-      must_be_non_negative: "должно быть неотрицательным числом"
+      exceeds_available_stock: превышает количество на складе. Пожалуйста проверьте количество товара.
+      is_too_large: слишком много - количество на складе меньше запрошенного количества!
+      must_be_int: должно быть целым числом
+      must_be_non_negative: должно быть неотрицательным числом
       unpaid_amount_not_zero:
-    value: "Значение"
-    variant: "Вариант"
-    variant_placeholder: "Выберите вариант"
-    variant_search_placeholder: "Выберите артикул или вариант"
-    variants: "Варианты"
-    version: "Версия"
-    void: "Аннулировать"
-    weight: "Вес"
-    what_is_a_cvv: "Что такое CVV?"
-    what_is_this: "Что это?"
-    width: "Ширина"
-    year: "Год"
-    you_have_no_orders_yet: "У Вас ещё нет заказов."
-    your_cart_is_empty: "Ваша корзина пуста"
-    your_order_is_empty_add_product: "Ваша корзина пуста, найдите и добавьте продукты, пожалуйста"
-    zip: "Индекс"
-    zipcode: "Почтовый индекс"
-    zone: "Торговая зона"
-    zones: "Торговые зоны"
+    value: Значение
+    variant: Вариант
+    variant_placeholder: Выберите вариант
+    variant_search_placeholder: Выберите артикул или вариант
+    variants: Варианты
+    version: Версия
+    void: Аннулировать
+    weight: Вес
+    what_is_a_cvv: Что такое CVV?
+    what_is_this: Что это?
+    width: Ширина
+    year: Год
+    you_have_no_orders_yet: У Вас ещё нет заказов.
+    your_cart_is_empty: Ваша корзина пуста
+    your_order_is_empty_add_product: Ваша корзина пуста, найдите и добавьте продукты, пожалуйста
+    zip: Индекс
+    zipcode: Почтовый индекс
+    zone: Торговая зона
+    zones: Торговые зоны
+    canceled: Отменён
+    cannot_create_payment_link: Сначала определите способ оплаты.
+    inventory_states:
+      canceled: Отменён
+      returned: Возвращён
+      shipped: отправлен
+    no_resource_found_link: Добавить
+    number: Номер
+    store_credit:
+      display_action:
+        adjustment: Корректировка
+        credit: Кредит
+        void: Кредит
+        admin:
+          authorize:
+    store_credit_category:
+      default: По умолчанию
+  activemodel:
+    attributes:
+      spree/order_cancellations:
+        quantity: Количество
+        state: Регион/Область
+        shipment: Отправка
+        cancel: Отменить


### PR DESCRIPTION
Recent changes made to admin translations in solidus moved many of the keys. This was done to better use the ActiveModel translation conventions.

I wrote a [script](https://github.com/StemboltHQ/solidus_i18n_convert) that scans through the locale files in solidus_i18n looking for missing keys when compared to `en.yml` in core. Since these translations are just moved, the script attempts to make the same moves in this locale as were made for english.

Reviews would be appreciated to find any blatant mistranslations.
