### PR TITLE
Convert ko translations from solidus 1.2 -> 1.3

### DIFF
--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,3 +1,4 @@
+---
 ko:
   activerecord:
     attributes:
@@ -11,6 +12,7 @@ ko:
         phone:
         state:
         zipcode:
+        company:
       spree/calculator/tiered_flat_rate:
         preferred_base_amount:
         preferred_tiers:
@@ -23,6 +25,7 @@ ko:
         iso_name:
         name:
         numcode:
+        states_required:
       spree/credit_card:
         base:
         cc_type:
@@ -31,11 +34,16 @@ ko:
         number:
         verification_value:
         year:
+        card_code: 카드 코드
+        expiration: 유효 기간
       spree/inventory_unit:
         state:
       spree/line_item:
         price:
         quantity:
+        description: 아이템 설명
+        name: 이름
+        total:
       spree/option_type:
         name:
         presentation:
@@ -54,6 +62,13 @@ ko:
         special_instructions:
         state:
         total:
+        additional_tax_total: 세금
+        approved_at:
+        approver_id:
+        canceled_at:
+        canceler_id:
+        included_tax_total:
+        shipment_total:
       spree/order/bill_address:
         address1:
         city:
@@ -72,8 +87,16 @@ ko:
         zipcode:
       spree/payment:
         amount:
+        number:
+        response_code:
+        state: 지불 상태
       spree/payment_method:
         name:
+        active: 활성
+        auto_capture:
+        description: 설명
+        display_on: 표시
+        type: 제공자
       spree/product:
         available_on:
         cost_currency:
@@ -84,6 +107,16 @@ ko:
         on_hand:
         shipping_category:
         tax_category:
+        depth: 높이
+        height: 세로
+        meta_description: 메타 설명
+        meta_keywords: 메타 키워드
+        meta_title:
+        price: 기본 가격
+        promotionable:
+        slug:
+        weight: 무게
+        width: 가로
       spree/promotion:
         advertise:
         code:
@@ -103,6 +136,7 @@ ko:
         name:
       spree/return_authorization:
         amount:
+        pre_tax_total:
       spree/role:
         name:
       spree/state:
@@ -126,14 +160,22 @@ ko:
       spree/tax_category:
         description:
         name:
+        is_default: 기본
+        tax_code:
       spree/tax_rate:
         amount:
         included_in_price:
         show_rate_in_label:
+        name: 이름
       spree/taxon:
         name:
         permalink:
         position:
+        description: 설명
+        icon: 아이콘
+        meta_description: 메타 설명
+        meta_keywords: 메타 키워드
+        meta_title:
       spree/taxonomy:
         name:
       spree/user:
@@ -152,6 +194,118 @@ ko:
       spree/zone:
         description:
         name:
+        default_tax:
+      spree/adjustment:
+        adjustable:
+        amount: 액수
+        label: 설명
+        name: 이름
+        state:
+        adjustment_reason_id: 이유
+      spree/adjustment_reason:
+        active: 활성
+        code: 코드
+        name: 이름
+        state:
+      spree/carton:
+        tracking:
+      spree/customer_return:
+        number:
+        pre_tax_total:
+        total: 합계
+        reimbursement_status:
+        name: 이름
+      spree/image:
+        alt: 대체 텍스트
+        attachment: 파일이름
+      spree/legacy_user:
+        email: 이메일
+        password: 비밀번호
+        password_confirmation: 비밀번호 확인
+      spree/option_value:
+        name: 이름
+        presentation: 표시
+      spree/product_property:
+        value: 값
+      spree/refund:
+        amount: 액수
+        description: 설명
+        refund_reason_id: 이유
+      spree/refund_reason:
+        active: 활성
+        name: 이름
+        code: 코드
+      spree/reimbursement:
+        number:
+        reimbursement_status: 상태
+        total: 합계
+      spree/reimbursement/credit:
+        amount: 액수
+      spree/reimbursement_type:
+        name: 이름
+        type:
+      spree/return_item:
+        acceptance_status:
+        acceptance_status_errors:
+        charged:
+        exchange_variant:
+        inventory_unit_state:
+        override_reimbursement_type_id:
+        preferred_reimbursement_type_id:
+        reception_status:
+        return_reason: 이유
+        total: 합계
+      spree/return_reason:
+        name: 이름
+        active: 활성
+        memo:
+        number: RMA 번호
+        state:
+      spree/shipping_category:
+        name: 이름
+      spree/shipment:
+        tracking:
+      spree/shipping_method:
+        admin_name:
+        code: 코드
+        display_on: 표시
+        name: 이름
+        tracking_url:
+      spree/shipping_rate:
+        amount: 액수
+      spree/store_credit:
+        amount: 액수
+        memo:
+      spree/store_credit_event:
+        action: 행동
+      spree/stock_item:
+        count_on_hand:
+      spree/stock_location:
+        admin_name:
+        active: 활성
+        address1: Street 주소
+        address2: Street 주소 (cont'd)
+        backorderable_default:
+        city:
+        code: 코드
+        country_id: 국가
+        default: 기본
+        internal_name:
+        name: 이름
+        phone: 전화번호
+        propagate_all_variants:
+        state_id:
+        zipcode: 우편번호
+      spree/stock_movement:
+        action: 행동
+        quantity:
+      spree/stock_transfer:
+        created_at:
+        description: 설명
+        tracking_number:
+      spree/tracker:
+        analytics_id: 애날리스틱 ID
+        active: 활성
     errors:
       models:
         spree/calculator/tiered_flat_rate:
@@ -200,43 +354,123 @@ ko:
               cannot_destroy_default_store:
     models:
       spree/address:
+        one:
+        other:
       spree/country:
+        one: 국가
+        other:
       spree/credit_card:
+        one: 신용카드
+        other:
       spree/customer_return:
+        one:
+        other:
       spree/inventory_unit:
       spree/line_item:
       spree/option_type:
+        one: 옵션 타입
+        other: 옵션 타입
       spree/option_value:
+        one: 옵션 값
+        other: 옵션 값
       spree/order:
+        one: 주문
+        other: 주문
       spree/payment:
+        one: 지불
+        other: 지불
       spree/payment_method:
+        one: 결제 방법
+        other: 결제 방법
       spree/product:
+        one: 상품
+        other: 상품
       spree/promotion:
+        one:
+        other:
       spree/promotion_category:
+        other:
       spree/property:
+        one: 속성
+        other: 속성
       spree/prototype:
+        one: 견본
+        other: 견본
       spree/refund_reason:
+        other:
       spree/reimbursement:
+        one:
+        other:
       spree/reimbursement_type:
+        other:
       spree/return_authorization:
+        one:
+        other:
       spree/return_authorization_reason:
       spree/role:
+        one:
+        other:
       spree/shipment:
+        one: 배송
+        other: 배송
       spree/shipping_category:
+        one: 배송 분류
+        other: 배송 분류
       spree/shipping_method:
+        one:
+        other:
       spree/state:
+        one:
+        other:
       spree/state_change:
       spree/stock_location:
+        one:
+        other:
       spree/stock_movement:
+        other:
       spree/stock_transfer:
+        one:
+        other:
       spree/tax_category:
+        one: 세금 분류
+        other: 세금 분류
       spree/tax_rate:
+        other: 세율
       spree/taxon:
+        one: 분류군
+        other: 종류
       spree/taxonomy:
+        one: 분류군
+        other: 분류계
       spree/tracker:
+        other: 애날리틱스 트래커
       spree/user:
+        one: 사용자
+        other: 사용자
       spree/variant:
+        one:
+        other: 품종
       spree/zone:
+        one: 지역
+        other: 지역
+      spree/adjustment:
+        one: 정산
+        other: 정산
+      spree/calculator:
+        one: 계산기
+      spree/legacy_user:
+        one: 사용자
+        other: 사용자
+      spree/log_entry:
+        other:
+      spree/product_property:
+        other: 상품 속성
+      spree/refund:
+        one:
+        other:
+      spree/store_credit_category:
+        one:
+        other:
   devise:
     confirmations:
       confirmed:
@@ -282,54 +516,59 @@ ko:
       not_locked:
       not_saved:
   spree:
-    abbreviation: "생략"
+    abbreviation: 생략
     accept:
     acceptance_errors:
     acceptance_status:
     accepted:
-    account: "계정"
-    account_updated: "계정 정보가 수정되었습니다!"
-    action: "행동"
+    account: 계정
+    account_updated: 계정 정보가 수정되었습니다!
+    action: 행동
     actions:
-      cancel: "취소"
+      cancel: 취소
       continue:
-      create: "생성"
-      destroy: "삭제"
+      create: 생성
+      destroy: 삭제
       edit:
-      list: "목록"
-      listing: "목록"
+      list: 목록
+      listing: 목록
       new:
       refund:
       save:
-      update: "수정"
+      update: 수정
+      add: 추가
+      delete: 삭제
+      remove: 삭제
+      ship:
+      split:
     activate:
-    active: "활성"
-    add: "추가"
+    active: 활성
+    add: 추가
     add_action_of_type:
-    add_country: "국가 추가"
+    add_country: 국가 추가
     add_coupon_code:
     add_new_header:
     add_new_style:
     add_one:
-    add_option_value: "옵션 값 추가"
-    add_product: "상품 추가"
-    add_product_properties: "상품 속성 추가"
+    add_option_value: 옵션 값 추가
+    add_product: 상품 추가
+    add_product_properties: 상품 속성 추가
     add_rule_of_type:
     add_state:
     add_stock:
     add_stock_management:
-    add_to_cart: "장바구니에 추가"
+    add_to_cart: 장바구니에 추가
     add_variant:
-    additional_item: "추가 된 아이템 비용"
+    additional_item: 추가 된 아이템 비용
     address1:
     address2:
     adjustable:
-    adjustment: "정산"
+    adjustment: 정산
     adjustment_amount:
     adjustment_successfully_closed:
     adjustment_successfully_opened:
-    adjustment_total: "정산 합계"
-    adjustments: "정산"
+    adjustment_total: 정산 합계
+    adjustments: 정산
     admin:
       tab:
         configuration:
@@ -345,6 +584,12 @@ ko:
         taxonomies:
         taxons:
         users:
+        checkout:
+        general:
+        payments: 지불
+        settings: 설정
+        shipping: 배송료
+        stock:
       user:
         account:
         addresses:
@@ -354,11 +599,11 @@ ko:
         order_num:
         orders:
         user_information:
-    administration: "관리"
+    administration: 관리
     advertise:
     agree_to_privacy_policy:
     agree_to_terms_of_service:
-    all: "전체"
+    all: 전체
     all_adjustments_closed:
     all_adjustments_opened:
     all_departments:
@@ -367,66 +612,66 @@ ko:
     allow_ssl_in_production:
     allow_ssl_in_staging:
     already_signed_up_for_analytics:
-    alt_text: "대체 텍스트"
-    alternative_phone: "휴대폰 번호"
-    amount: "액수"
+    alt_text: 대체 텍스트
+    alternative_phone: 휴대폰 번호
+    amount: 액수
     analytics_desc_header_1:
     analytics_desc_header_2:
     analytics_desc_list_1:
     analytics_desc_list_2:
     analytics_desc_list_3:
     analytics_desc_list_4:
-    analytics_trackers: "애날리틱스 트래커"
+    analytics_trackers: 애날리틱스 트래커
     and:
     approve:
     approved_at:
     approver:
-    are_you_sure: "확실합니까?"
-    are_you_sure_delete: "기록을 삭제하시겠습니까?"
+    are_you_sure: 확실합니까?
+    are_you_sure_delete: 기록을 삭제하시겠습니까?
     associated_adjustment_closed:
-    at_symbol: '@'
-    authorization_failure: "인증 실패"
+    at_symbol: "@"
+    authorization_failure: 인증 실패
     authorized:
     auto_capture:
-    available_on: "시작일"
+    available_on: 시작일
     average_order_value:
     avs_response:
-    back: "뒤로"
+    back: 뒤로
     back_end:
     back_to_payment:
     back_to_resource_list:
     back_to_rma_reason_list:
-    back_to_store: "스토어로 돌아가기"
+    back_to_store: 스토어로 돌아가기
     back_to_users_list:
     backorderable:
     backorderable_default:
     backordered:
     backorders_allowed:
-    balance_due: "부족"
+    balance_due: 부족
     base_amount:
     base_percent:
-    bill_address: "청구서 주소"
-    billing: "청구서"
-    billing_address: "청구서 주소"
-    both: "양 쪽 모두"
+    bill_address: 청구서 주소
+    billing: 청구서
+    billing_address: 청구서 주소
+    both: 양 쪽 모두
     calculated_reimbursements:
-    calculator: "계산기"
+    calculator: 계산기
     calculator_settings_warning:
-    cancel: "취소"
+    cancel: 취소
     canceled_at:
     canceler:
     cannot_create_customer_returns:
     cannot_create_payment_without_payment_methods:
     cannot_create_returns:
-    cannot_perform_operation: "요청한 명령을 실핼 할 수 없습니다"
+    cannot_perform_operation: 요청한 명령을 실핼 할 수 없습니다
     cannot_set_shipping_method_without_address:
-    capture: "캡쳐"
+    capture: 캡쳐
     capture_events:
-    card_code: "카드 코드"
-    card_number: "카드 번호"
+    card_code: 카드 코드
+    card_number: 카드 번호
     card_type:
-    card_type_is: "카드 종료는 입니다"
-    cart: "장바구니"
+    card_type_is: 카드 종료는 입니다
+    cart: 장바구니
     cart_subtotal:
     categories:
     category:
@@ -443,36 +688,36 @@ ko:
     clear_cache_ok:
     clear_cache_warning:
     click_and_drag_on_the_products_to_sort_them:
-    clone: "복사"
+    clone: 복사
     close:
     close_all_adjustments:
-    code: "코드"
+    code: 코드
     company:
-    complete: "완료"
-    configuration: "설정"
-    configurations: "설정"
-    confirm: "확인"
+    complete: 완료
+    configuration: 설정
+    configurations: 설정
+    confirm: 확인
     confirm_delete:
-    confirm_password: "비밀번호 확인"
-    continue: "계속"
-    continue_shopping: "계속 쇼핑"
+    confirm_password: 비밀번호 확인
+    continue: 계속
+    continue_shopping: 계속 쇼핑
     cost_currency:
-    cost_price: "비용"
+    cost_price: 비용
     could_not_connect_to_jirafe:
     could_not_create_customer_return:
     could_not_create_stock_movement:
     count_on_hand:
     countries:
-    country: "국가"
-    country_based: "국가 기반"
+    country: 국가
+    country_based: 국가 기반
     country_name:
     country_names:
       CA:
       FRA:
       ITA:
       US:
-    coupon: "쿠폰"
-    coupon_code: "쿠폰 코드"
+    coupon: 쿠폰
+    coupon_code: 쿠폰 코드
     coupon_code_already_applied:
     coupon_code_applied:
     coupon_code_better_exists:
@@ -481,13 +726,13 @@ ko:
     coupon_code_not_eligible:
     coupon_code_not_found:
     coupon_code_unknown_error:
-    create: "생성"
-    create_a_new_account: "새 계정 생성"
+    create: 생성
+    create_a_new_account: 새 계정 생성
     create_new_order:
     create_reimbursement:
     created_at:
     credit:
-    credit_card: "신용카드"
+    credit_card: 신용카드
     credit_cards:
     credit_owed:
     credits:
@@ -496,14 +741,14 @@ ko:
     currency_settings:
     currency_symbol_position:
     currency_thousands_separator:
-    current: "현재"
+    current: 현재
     current_promotion_usage:
-    customer: "고객"
-    customer_details: "고객 정보"
+    customer: 고객
+    customer_details: 고객 정보
     customer_details_updated:
     customer_return:
     customer_returns:
-    customer_search: "고객 검색"
+    customer_search: 고객 검색
     cut:
     cvv_response:
     dash:
@@ -522,28 +767,28 @@ ko:
       first_day:
       format:
       js_format:
-    date_range: "날짜 범위"
-    default: "기본"
+    date_range: 날짜 범위
+    default: 기본
     default_refund_amount:
     default_tax:
     default_tax_zone:
-    delete: "삭제"
+    delete: 삭제
     deleted_variants_present:
     delivery:
-    depth: "높이"
-    description: "설명"
+    depth: 높이
+    description: 설명
     destination:
-    destroy: "삭제"
+    destroy: 삭제
     details:
-    discount_amount: "할인액"
+    discount_amount: 할인액
     dismiss_banner:
-    display: "표시"
+    display: 표시
     display_currency:
     doesnt_track_inventory:
-    edit: "편집"
+    edit: 편집
     editing_resource:
     editing_rma_reason:
-    editing_user: "사용자 편집"
+    editing_user: 사용자 편집
     eligibility_errors:
       messages:
         has_excluded_product:
@@ -559,23 +804,23 @@ ko:
         no_user_or_email_specified:
         no_user_specified:
         not_first_order:
-    email: "이메일"
+    email: 이메일
     empty:
-    empty_cart: "장바구니 비우기"
+    empty_cart: 장바구니 비우기
     enable_mail_delivery:
     end:
     ending_in:
-    environment: "환경"
-    error: "에러"
+    environment: 환경
+    error: 에러
     errors:
       messages:
         could_not_create_taxon:
         no_payment_methods_available:
         no_shipping_methods_available:
     errors_prohibited_this_record_from_being_saved:
-      one: "저장하는 중에 문제가 발생했습니다."
-      other: "저장하는 중에 문제가 %{count}개 발생했습니다."
-    event: "이벤트"
+      one: 저장하는 중에 문제가 발생했습니다.
+      other: 저장하는 중에 문제가 %{count}개 발생했습니다.
+    event: 이벤트
     events:
       spree:
         cart:
@@ -595,47 +840,47 @@ ko:
     excl:
     existing_shipments:
     expedited_exchanges_warning:
-    expiration: "유효 기간"
-    extension: "확장"
+    expiration: 유효 기간
+    extension: 확장
     failed_payment_attempts:
-    filename: "파일이름"
+    filename: 파일이름
     fill_in_customer_info:
     filter_results:
     finalize:
     finalized:
     find_a_taxon:
-    first_item: "첫 아이템 비용"
-    first_name: "이름"
-    first_name_begins_with: "이름으로 시작"
+    first_item: 첫 아이템 비용
+    first_name: 이름
+    first_name_begins_with: 이름으로 시작
     flat_percent:
     flat_rate_per_order:
     flexible_rate:
     forgot_password:
-    free_shipping: "무료 배송"
+    free_shipping: 무료 배송
     free_shipping_amount:
     front_end:
-    gateway: "게이트웨이"
+    gateway: 게이트웨이
     gateway_config_unavailable:
-    gateway_error: "게이트웨이 에러"
+    gateway_error: 게이트웨이 에러
     general:
-    general_settings: "일반 설정"
-    google_analytics: "구글 애날리스틱"
-    google_analytics_id: "애날리스틱 ID"
-    guest_checkout: "비회원 주문"
-    guest_user_account: "비회원으로 결제"
+    general_settings: 일반 설정
+    google_analytics: 구글 애날리스틱
+    google_analytics_id: 애날리스틱 ID
+    guest_checkout: 비회원 주문
+    guest_user_account: 비회원으로 결제
     has_no_shipped_units:
-    height: "세로"
+    height: 세로
     hide_cents:
     home: Home
     i18n:
       available_locales:
       language:
       localization_settings:
-      this_file_language: "한국어 (KO)"
-    icon: "아이콘"
+      this_file_language: 한국어 (KO)
+    icon: 아이콘
     identifier:
-    image: "이미지"
-    images: "이미지"
+    image: 이미지
+    images: 이미지
     implement_eligible_for_return:
     implement_requires_manual_intervention:
     inactive:
@@ -656,19 +901,19 @@ ko:
     invalid_payment_provider:
     invalid_promotion_action:
     invalid_promotion_rule:
-    inventory: "인벤토리"
-    inventory_adjustment: "인벤토리 정산"
+    inventory: 인벤토리
+    inventory_adjustment: 인벤토리 정산
     inventory_error_flash_for_insufficient_quantity:
     inventory_state:
     is_not_available_to_shipment_address:
     iso_name:
-    item: "아이템"
-    item_description: "아이템 설명"
-    item_total: "아이템 합계"
+    item: 아이템
+    item_description: 아이템 설명
+    item_total: 아이템 합계
     item_total_rule:
       operators:
-        gt: "보다 큰"
-        gte: "보다 크거나 같은"
+        gt: 보다 큰
+        gte: 보다 크거나 같은
         lt:
         lte:
     items_cannot_be_shipped:
@@ -678,68 +923,68 @@ ko:
     jirafe:
     landing_page_rule:
       path: Path
-    last_name: "성"
-    last_name_begins_with: "성으로 시작"
+    last_name: 성
+    last_name_begins_with: 성으로 시작
     learn_more: Learn More
     lifetime_stats:
     line_item_adjustments:
-    list: "목록"
-    loading: "로딩"
-    locale_changed: "지역이 변경됨"
+    list: 목록
+    loading: 로딩
+    locale_changed: 지역이 변경됨
     location:
     lock:
     log_entries:
     logged_in_as:
-    logged_in_succesfully: "로그인 성공"
-    logged_out: "로그아웃 되었습니다."
-    login: "로그인"
+    logged_in_succesfully: 로그인 성공
+    logged_out: 로그아웃 되었습니다.
+    login: 로그인
     login_as_existing:
     login_failed:
-    login_name: "로그인"
-    logout: "로그아웃"
+    login_name: 로그인
+    logout: 로그아웃
     logs:
-    look_for_similar_items: "비슷한 상품들"
+    look_for_similar_items: 비슷한 상품들
     make_refund:
     make_sure_the_above_reimbursement_amount_is_correct:
     manage_promotion_categories:
     manage_variants:
     manual_intervention_required:
-    master_price: "기본 가격"
+    master_price: 기본 가격
     match_choices:
       all:
       none:
-    max_items: "최대 아이템"
+    max_items: 최대 아이템
     member_since:
     memo:
-    meta_description: "메타 설명"
-    meta_keywords: "메타 키워드"
+    meta_description: 메타 설명
+    meta_keywords: 메타 키워드
     meta_title:
-    metadata: "메타데이터"
-    minimal_amount: "최소량"
+    metadata: 메타데이터
+    minimal_amount: 최소량
     month:
     more:
     move_stock_between_locations:
-    my_account: "내 계정"
-    my_orders: "내 주문"
-    name: "이름"
+    my_account: 내 계정
+    my_orders: 내 주문
+    name: 이름
     name_on_card:
-    name_or_sku: "이름 또는 SKU"
+    name_or_sku: 이름 또는 SKU
     new:
-    new_adjustment: "새 정산"
+    new_adjustment: 새 정산
     new_country:
-    new_customer: "새 고객"
+    new_customer: 새 고객
     new_customer_return:
-    new_image: "새 이미지"
-    new_option_type: "새 옵션 타입"
-    new_order: "새 주문"
+    new_image: 새 이미지
+    new_option_type: 새 옵션 타입
+    new_order: 새 주문
     new_order_completed:
-    new_payment: "새 결제"
-    new_payment_method: "새 결제 방법"
-    new_product: "새 상품"
-    new_promotion: "새 프로모션"
+    new_payment: 새 결제
+    new_payment_method: 새 결제 방법
+    new_product: 새 상품
+    new_promotion: 새 프로모션
     new_promotion_category:
-    new_property: "새 속성"
-    new_prototype: "새 견본"
+    new_property: 새 속성
+    new_prototype: 새 견본
     new_refund:
     new_refund_reason:
     new_return_authorization:
@@ -751,27 +996,27 @@ ko:
     new_stock_location:
     new_stock_movement:
     new_stock_transfer:
-    new_tax_category: "새 세금 분류"
-    new_tax_rate: "새로운 세율"
-    new_taxon: "새 분류군"
-    new_taxonomy: "새 분류계"
-    new_tracker: "새 트랙커"
-    new_user: "새 사용자"
-    new_variant: "새 품종"
-    new_zone: "새 지역"
-    next: "다음"
+    new_tax_category: 새 세금 분류
+    new_tax_rate: 새로운 세율
+    new_taxon: 새 분류군
+    new_taxonomy: 새 분류계
+    new_tracker: 새 트랙커
+    new_user: 새 사용자
+    new_variant: 새 품종
+    new_zone: 새 지역
+    next: 다음
     no_actions_added:
     no_payment_found:
     no_pending_payments:
-    no_products_found: "찾는 상품이 없음"
+    no_products_found: 찾는 상품이 없음
     no_resource_found:
-    no_results: "결과가 없음"
+    no_results: 결과가 없음
     no_returns_found:
-    no_rules_added: "추가 된 규칙이 없음"
+    no_rules_added: 추가 된 규칙이 없음
     no_shipping_method_selected:
     no_state_changes:
     no_tracking_present:
-    none: "없음"
+    none: 없음
     none_selected:
     normal_amount:
     not:
@@ -784,45 +1029,47 @@ ko:
       product_deleted:
       product_not_cloned:
       product_not_deleted:
-      variant_deleted: "품종이 삭제됐습니다"
-      variant_not_deleted: "품종을 삭제할 수 없습니다"
+      variant_deleted: 품종이 삭제됐습니다
+      variant_not_deleted: 품종을 삭제할 수 없습니다
     num_orders:
-    on_hand: "재고"
+    on_hand: 재고
     open:
     open_all_adjustments:
-    option_type: "옵션 타입"
+    option_type: 옵션 타입
     option_type_placeholder:
-    option_types: "옵션 타입"
-    option_value: "옵션 값"
-    option_values: "옵션 값"
+    option_types: 옵션 타입
+    option_value: 옵션 값
+    option_values: 옵션 값
     optional:
-    options: "옵션"
-    or: "또는"
+    options: 옵션
+    or: 또는
     or_over_price:
-    order: "주문"
+    order: 주문
     order_adjustments:
     order_already_updated:
     order_approved:
     order_canceled:
-    order_details: "주문 상세"
-    order_email_resent: "주문 확인 메일 재발송"
+    order_details: 주문 상세
+    order_email_resent: 주문 확인 메일 재발송
     order_information:
     order_mailer:
       cancel_email:
         dear_customer:
         instructions:
         order_summary_canceled:
-        subject: "주문 취소"
+        subject: 주문 취소
         subtotal:
         total:
       confirm_email:
         dear_customer:
         instructions:
         order_summary:
-        subject: "주문 확인"
+        subject: 주문 확인
         subtotal:
         thanks:
         total:
+      inventory_cancellation:
+        dear_customer:
     order_not_found:
     order_number:
     order_populator:
@@ -832,62 +1079,62 @@ ko:
     order_processed_successfully:
     order_resumed:
     order_state:
-      address: "주소"
+      address: 주소
       awaiting_return:
-      canceled: "취소됨"
-      cart: "장바구니"
-      complete: "완료"
-      confirm: "확인"
+      canceled: 취소됨
+      cart: 장바구니
+      complete: 완료
+      confirm: 확인
       considered_risky:
       delivery:
-      payment: "지불"
+      payment: 지불
       resumed:
       returned:
-    order_summary: "주문 요약"
+    order_summary: 주문 요약
     order_sure_want_to:
-    order_total: "주문 합계"
-    order_updated: "주문이 수정됨"
-    orders: "주문"
+    order_total: 주문 합계
+    order_updated: 주문이 수정됨
+    orders: 주문
     other_items_in_other:
-    out_of_stock: "품절"
+    out_of_stock: 품절
     overview: Overiew
     package_from:
     pagination:
       next_page:
       previous_page:
       truncate: "…"
-    password: "비밀번호"
+    password: 비밀번호
     paste:
-    path: "경로"
+    path: 경로
     pay:
-    payment: "지불"
+    payment: 지불
     payment_could_not_be_created:
     payment_identifier:
-    payment_information: "지불 정보"
-    payment_method: "결제 방법"
+    payment_information: 지불 정보
+    payment_method: 결제 방법
     payment_method_not_supported:
-    payment_methods: "결제 방법"
-    payment_processing_failed: "결제 중에 문제가 발생했습니다. 잠시 후에 다시 해보시기 바랍니다."
+    payment_methods: 결제 방법
+    payment_processing_failed: 결제 중에 문제가 발생했습니다. 잠시 후에 다시 해보시기 바랍니다.
     payment_processor_choose_banner_text:
     payment_processor_choose_link:
-    payment_state: "지불 상태"
+    payment_state: 지불 상태
     payment_states:
-      balance_due: "부족"
+      balance_due: 부족
       checkout:
-      completed: "완료"
+      completed: 완료
       credit_owed:
       failed:
-      paid: "지불"
-      pending: "보류"
+      paid: 지불
+      pending: 보류
       processing:
       void:
     payment_updated:
-    payments: "지불"
+    payments: 지불
     pending:
     percent:
     percent_per_item:
-    permalink: "퍼마링크"
-    phone: "전화번호"
+    permalink: 퍼마링크
+    phone: 전화번호
     place_order:
     please_define_payment_methods:
     populate_get_error:
@@ -896,28 +1143,28 @@ ko:
     pre_tax_refund_amount:
     pre_tax_total:
     preferred_reimbursement_type:
-    presentation: "표시"
-    previous: "이전"
+    presentation: 표시
+    previous: 이전
     previous_state_missing:
-    price: "가격"
+    price: 가격
     price_range:
     price_sack:
-    process: "과정"
-    product: "상품"
-    product_details: "상품 상세"
+    process: 과정
+    product: 상품
+    product_details: 상품 상세
     product_has_no_description:
     product_not_available_in_this_currency:
-    product_properties: "상품 속성"
+    product_properties: 상품 속성
     product_rule:
-      choose_products: "상품 선택"
+      choose_products: 상품 선택
       label:
-      match_all: "모두"
-      match_any: "최소 하나"
+      match_all: 모두
+      match_any: 최소 하나
       match_none:
       product_source:
-        group: "상품군에서"
+        group: 상품군에서
         manual:
-    products: "상품"
+    products: 상품
     promotion:
     promotion_action:
     promotion_action_types:
@@ -936,13 +1183,13 @@ ko:
     promotion_actions:
     promotion_form:
       match_policies:
-        all: "이 규칙에 모두 일치"
-        any: "이 규칙에 하나라도 일치"
+        all: 이 규칙에 모두 일치
+        any: 이 규칙에 하나라도 일치
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:
         description:
-        name: "첫 주문"
+        name: 첫 주문
       item_total:
         description:
         name:
@@ -971,19 +1218,19 @@ ko:
     promotionable:
     promotions:
     propagate_all_variants:
-    properties: "속성"
-    property: "속성"
-    prototype: "견본"
-    prototypes: "견본"
-    provider: "제공자"
+    properties: 속성
+    property: 속성
+    prototype: 견본
+    prototypes: 견본
+    provider: 제공자
     provider_settings_warning:
-    qty: "수량"
+    qty: 수량
     quantity:
     quantity_returned:
     quantity_shipped:
     quick_search:
     rate:
-    reason: "이유"
+    reason: 이유
     receive:
     receive_stock:
     received:
@@ -995,7 +1242,7 @@ ko:
     refunded_amount:
     refunds:
     register:
-    registration: "등록"
+    registration: 등록
     reimburse:
     reimbursed:
     reimbursement:
@@ -1017,14 +1264,14 @@ ko:
     reimbursements:
     reject:
     rejected:
-    remember_me: "이메일 저장"
-    remove: "삭제"
+    remember_me: 이메일 저장
+    remove: 삭제
     rename:
     report:
-    reports: "리포트"
-    resend: "재발송"
-    reset_password: "비밀번호 재설정"
-    response_code: "응답 코드"
+    reports: 리포트
+    resend: 재발송
+    reset_password: 비밀번호 재설정
+    response_code: 응답 코드
     resume:
     resumed:
     return:
@@ -1047,38 +1294,38 @@ ko:
     risk_analysis:
     risky:
     rma_credit:
-    rma_number: "RMA 번호"
-    rma_value: "RMA 값"
+    rma_number: RMA 번호
+    rma_value: RMA 값
     roles:
-    rules: "규칙"
+    rules: 규칙
     safe:
     sales_total:
     sales_total_description:
     sales_totals:
-    save_and_continue: "저장하고 계속"
+    save_and_continue: 저장하고 계속
     save_my_address:
     say_no: false
     say_yes: true
-    scope: "범위"
-    search: "검색"
+    scope: 범위
+    search: 검색
     search_results: "%{keywords}의 검색 결과"
-    searching: "검색중"
+    searching: 검색중
     secure_connection_type:
     security_settings:
-    select: "선택"
+    select: 선택
     select_a_return_authorization_reason:
     select_a_stock_location:
-    select_from_prototype: "견본에서 선택"
+    select_from_prototype: 견본에서 선택
     select_stock:
-    send_copy_of_all_mails_to: "모든 메일 사본을 다음 주소로 보냄"
+    send_copy_of_all_mails_to: 모든 메일 사본을 다음 주소로 보냄
     send_mails_as:
-    server: "서버"
+    server: 서버
     server_error:
-    settings: "설정"
+    settings: 설정
     ship:
-    ship_address: "배송 주소"
+    ship_address: 배송 주소
     ship_total:
-    shipment: "배송"
+    shipment: 배송
     shipment_adjustments:
     shipment_details:
     shipment_mailer:
@@ -1090,22 +1337,22 @@ ko:
         thanks:
         track_information:
         track_link:
-    shipment_state: "배송 상태"
+    shipment_state: 배송 상태
     shipment_states:
       backorder:
       canceled:
       partial:
-      pending: "보류"
-      ready: "대기"
+      pending: 보류
+      ready: 대기
       shipped:
     shipment_transfer_error:
     shipment_transfer_success:
-    shipments: "배송"
-    shipped: "배송됨"
-    shipping: "배송료"
-    shipping_address: "배송 주소"
-    shipping_categories: "배송 분류"
-    shipping_category: "배송 분류"
+    shipments: 배송
+    shipped: 배송됨
+    shipping: 배송료
+    shipping_address: 배송 주소
+    shipping_categories: 배송 분류
+    shipping_category: 배송 분류
     shipping_flat_rate_per_item:
     shipping_flat_rate_per_order:
     shipping_flexible_rate:
@@ -1115,11 +1362,11 @@ ko:
     shipping_price_sack:
     shipping_total:
     shop_by_taxonomy:
-    shopping_cart: "장바구니"
-    show: "보기"
+    shopping_cart: 장바구니
+    show: 보기
     show_active:
-    show_deleted: "삭제 된 상품까지 보기"
-    show_only_complete_orders: "완료 된 주문만 보기"
+    show_deleted: 삭제 된 상품까지 보기
+    show_only_complete_orders: 완료 된 주문만 보기
     show_only_considered_risky:
     show_rate_in_label:
     sku:
@@ -1131,7 +1378,7 @@ ko:
     spree_gateway_error_flash_for_checkout:
     ssl:
       change_protocol:
-    start: "시작"
+    start: 시작
     state:
     state_based:
     state_machine_states:
@@ -1168,7 +1415,7 @@ ko:
       void:
     states:
     states_required:
-    status: "상태"
+    status: 상태
     stock:
     stock_location:
     stock_location_info:
@@ -1181,8 +1428,8 @@ ko:
     stock_successfully_transferred:
     stock_transfer:
     stock_transfers:
-    stop: "끝"
-    store: "상점"
+    stop: 끝
+    store: 상점
     street_address: Street 주소
     street_address_2: Street 주소 (cont'd)
     subtotal:
@@ -1194,45 +1441,45 @@ ko:
     successfully_signed_up_for_analytics:
     successfully_updated:
     summary:
-    tax: "세금"
-    tax_categories: "세금 분류"
-    tax_category: "세금 분류"
+    tax: 세금
+    tax_categories: 세금 분류
+    tax_category: 세금 분류
     tax_code:
     tax_included:
     tax_rate_amount_explanation:
-    tax_rates: "세율"
-    taxon: "분류군"
-    taxon_edit: "분류군 편집"
+    tax_rates: 세율
+    taxon: 분류군
+    taxon_edit: 분류군 편집
     taxon_placeholder:
     taxon_rule:
       choose_taxons:
       label:
       match_all:
       match_any:
-    taxonomies: "분류계"
-    taxonomy: "분류군"
+    taxonomies: 분류계
+    taxonomy: 분류군
     taxonomy_edit:
     taxonomy_tree_error:
     taxonomy_tree_instruction:
-    taxons: "종류"
-    test: "테스트"
+    taxons: 종류
+    test: 테스트
     test_mailer:
       test_email:
         greeting:
         message:
         subject:
-    test_mode: "테스트 모드"
+    test_mode: 테스트 모드
     thank_you_for_your_order:
     there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields: "다음 값들에 문제가 있습니다"
+    there_were_problems_with_the_following_fields: 다음 값들에 문제가 있습니다
     this_order_has_already_received_a_refund:
-    thumbnail: "미리보기"
+    thumbnail: 미리보기
     tiered_flat_rate:
     tiered_percent:
     tiers:
     time:
-    to_add_variants_you_must_first_define: "품종을 추가하려면 먼저 정의해야 합니다"
-    total: "합계"
+    to_add_variants_you_must_first_define: 품종을 추가하려면 먼저 정의해야 합니다
+    total: 합계
     total_per_item:
     total_pre_tax_refund:
     total_price:
@@ -1255,17 +1502,17 @@ ko:
     unlock:
     unrecognized_card_type:
     unshippable_items:
-    update: "수정"
+    update: 수정
     updating:
     usage_limit:
     use_app_default:
-    use_billing_address: "배송받으실 분이 주문자와 동일합니다."
+    use_billing_address: 배송받으실 분이 주문자와 동일합니다.
     use_new_cc:
     use_s3:
-    user: "사용자"
+    user: 사용자
     user_rule:
       choose_users:
-    users: "사용자"
+    users: 사용자
     validation:
       cannot_be_less_than_shipped_units:
       cannot_destroy_line_item_as_inventory_units_have_shipped:
@@ -1274,21 +1521,45 @@ ko:
       must_be_int:
       must_be_non_negative:
       unpaid_amount_not_zero:
-    value: "값"
+    value: 값
     variant:
     variant_placeholder:
-    variants: "품종"
-    version: "버전"
+    variants: 품종
+    version: 버전
     void:
-    weight: "무게"
-    what_is_a_cvv: "신용카드 코드(CVV)란?"
+    weight: 무게
+    what_is_a_cvv: 신용카드 코드(CVV)란?
     what_is_this:
-    width: "가로"
-    year: "년"
+    width: 가로
+    year: 년
     you_have_no_orders_yet:
-    your_cart_is_empty: "장바구니가 비었습니다"
+    your_cart_is_empty: 장바구니가 비었습니다
     your_order_is_empty_add_product:
-    zip: "우편번호"
-    zipcode: "우편번호"
-    zone: "지역"
-    zones: "지역"
+    zip: 우편번호
+    zipcode: 우편번호
+    zone: 지역
+    zones: 지역
+    canceled: 취소됨
+    cannot_create_payment_link:
+    inventory_states:
+      canceled: 취소됨
+      returned:
+      shipped:
+    no_resource_found_link:
+    number:
+    store_credit:
+      display_action:
+        adjustment: 정산
+        credit:
+        void:
+        admin:
+          authorize:
+    store_credit_category:
+      default: 기본
+  activemodel:
+    attributes:
+      spree/order_cancellations:
+        quantity:
+        state:
+        shipment: 배송
+        cancel: 취소


### PR DESCRIPTION
Recent changes made to admin translations in solidus moved many of the keys. This was done to better use the ActiveModel translation conventions.

I wrote a [script](https://github.com/StemboltHQ/solidus_i18n_convert) that scans through the locale files in solidus_i18n looking for missing keys when compared to `en.yml` in core. Since these translations are just moved, the script attempts to make the same moves in this locale as were made for english.

Reviews would be appreciated to find any blatant mistranslations.
