### PR TITLE
Convert ja translations from solidus 1.2 -> 1.3

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,656 +2,656 @@ ja:
   activerecord:
     attributes:
       spree/address:
-        address1: "住所1"
-        address2: "住所2"
-        city: "市区町村"
-        country: "国"
-        firstname: "名前（名）"
-        lastname: "名前（姓）"
-        phone: "電話番号"
-        state: "都道府県（州）"
-        zipcode: "郵便番号"
+        address1: 住所1
+        address2: 住所2
+        city: 市区町村
+        country: 国
+        firstname: 名前（名）
+        lastname: 名前（姓）
+        phone: 電話番号
+        state: 都道府県（州）
+        zipcode: 郵便番号
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount: "基準量"
-        preferred_tiers: "列"
+        preferred_base_amount: 基準量
+        preferred_tiers: 列
       spree/calculator/tiered_percent:
-        preferred_base_percent: "基本％"
-        preferred_tiers: "列"
+        preferred_base_percent: 基本％
+        preferred_tiers: 列
       spree/country:
         iso: ISO
         iso3: ISO3
         iso_name: ISO名
-        name: "名"
+        name: 名
         numcode: ISOコード
       spree/credit_card:
         base:
-        cc_type: "カード類"
-        month: "月"
-        name: "名前"
-        number: "カード番号"
-        verification_value: "照合コード"
-        year: "年"
+        cc_type: カード類
+        month: 月
+        name: 名前
+        number: カード番号
+        verification_value: 照合コード
+        year: 年
       spree/inventory_unit:
-        state: "都道府県（州）"
+        state: 都道府県（州）
       spree/line_item:
-        price: "価格"
-        quantity: "数量"
+        price: 価格
+        quantity: 数量
       spree/option_type:
-        name: "名称"
-        presentation: "表示"
+        name: 名称
+        presentation: 表示
       spree/order:
-        checkout_complete: "注文の受け付けを完了しました"
-        completed_at: "完了日時"
-        considered_risky: "リスク度"
-        coupon_code: "クーポンコード"
-        created_at: "注文日"
-        email: "メールアドレス"
+        checkout_complete: 注文の受け付けを完了しました
+        completed_at: 完了日時
+        considered_risky: リスク度
+        coupon_code: クーポンコード
+        created_at: 注文日
+        email: メールアドレス
         ip_address: IPアドレス
-        item_total: "合計個数"
-        name: "注文"
-        number: "注文番号"
-        payment_state: "支払い状態"
-        shipment_state: "配送状態"
-        special_instructions: "特記事項"
-        state: "状態"
-        total: "合計"
+        item_total: 合計個数
+        name: 注文
+        number: 注文番号
+        payment_state: 支払い状態
+        shipment_state: 配送状態
+        special_instructions: 特記事項
+        state: 状態
+        total: 合計
       spree/order/bill_address:
-        address1: "請求先の住所"
-        city: "請求先の住所・市"
-        firstname: "請求先の名"
-        lastname: "請求先の姓"
-        phone: "請求先の電話番号"
-        state: "請求先の都道府県(州)"
-        zipcode: "請求先の郵便番号"
+        address1: 請求先の住所
+        city: 請求先の住所・市
+        firstname: 請求先の名
+        lastname: 請求先の姓
+        phone: 請求先の電話番号
+        state: 請求先の都道府県(州)
+        zipcode: 請求先の郵便番号
       spree/order/ship_address:
-        address1: "配送先の住所"
-        city: "配送先の市"
-        firstname: "配送先の名"
-        lastname: "配送先の姓"
-        phone: "配送先の電話番号"
-        state: "配送先の都道府県(州)"
-        zipcode: "配送先の郵便番号"
+        address1: 配送先の住所
+        city: 配送先の市
+        firstname: 配送先の名
+        lastname: 配送先の姓
+        phone: 配送先の電話番号
+        state: 配送先の都道府県(州)
+        zipcode: 配送先の郵便番号
       spree/payment:
-        amount: "金額"
-        number: "数量"
+        amount: 金額
+        number: 数量
       spree/payment_method:
-        name: "名称"
+        name: 名称
       spree/product:
-        available_on: "販売開始日"
-        cost_currency: "コストカレンシー"
-        cost_price: "原価"
-        description: "説明"
-        master_price: "値段"
-        name: "商品名"
-        on_hand: "入荷数"
-        shipping_category: "配達区間"
-        tax_category: "税区"
+        available_on: 販売開始日
+        cost_currency: コストカレンシー
+        cost_price: 原価
+        description: 説明
+        master_price: 値段
+        name: 商品名
+        on_hand: 入荷数
+        shipping_category: 配達区間
+        tax_category: 税区
       spree/promotion:
-        advertise: "表示する"
-        code: "コード"
-        description: "説明"
-        event_name: "イベント名"
-        expires_at: "有効期限"
-        name: "名称"
-        path: "パス"
-        starts_at: "開始日時"
-        usage_limit: "使用可能回数"
+        advertise: 表示する
+        code: コード
+        description: 説明
+        event_name: イベント名
+        expires_at: 有効期限
+        name: 名称
+        path: パス
+        starts_at: 開始日時
+        usage_limit: 使用可能回数
       spree/promotion_category:
-        name: "名前"
+        name: 名前
       spree/property:
-        name: "名称"
-        presentation: "表示"
+        name: 名称
+        presentation: 表示
       spree/prototype:
-        name: "名称"
+        name: 名称
       spree/return_authorization:
-        amount: "合計"
+        amount: 合計
       spree/role:
-        name: "名称"
+        name: 名称
       spree/shipment:
-        number: "数量"
+        number: 数量
       spree/state:
-        abbr: "略語"
-        name: "名称"
+        abbr: 略語
+        name: 名称
       spree/state_change:
-        state_changes: "状態変化"
-        state_from: "状態元"
-        state_to: "状態先"
-        timestamp: "日時"
-        type: "タイプ"
-        updated: "更新"
-        user: "ユーザー"
+        state_changes: 状態変化
+        state_from: 状態元
+        state_to: 状態先
+        timestamp: 日時
+        type: タイプ
+        updated: 更新
+        user: ユーザー
       spree/store:
-        mail_from_address: "メールアドレス"
-        meta_description: "メタ 説明"
-        meta_keywords: "メタ キーワード"
-        name: "サイト名"
-        seo_title: "SEO タイトル"
-        url: "サイトURL"
+        mail_from_address: メールアドレス
+        meta_description: メタ 説明
+        meta_keywords: メタ キーワード
+        name: サイト名
+        seo_title: SEO タイトル
+        url: サイトURL
       spree/tax_category:
-        description: "説明"
-        name: "名称"
+        description: 説明
+        name: 名称
       spree/tax_rate:
-        amount: "率"
-        included_in_price: "税込み"
-        show_rate_in_label: "税率を見る"
+        amount: 率
+        included_in_price: 税込み
+        show_rate_in_label: 税率を見る
       spree/taxon:
-        name: "名称"
-        permalink: "固定リンク"
-        position: "位置"
+        name: 名称
+        permalink: 固定リンク
+        position: 位置
       spree/taxonomy:
-        name: "名称"
+        name: 名称
       spree/user:
         email: Eメール
-        password: "パスワード"
-        password_confirmation: "パスワード（確認）"
+        password: パスワード
+        password_confirmation: パスワード（確認）
       spree/variant:
-        cost_currency: "コストカレンシー"
-        cost_price: "原価"
-        depth: "奥行き"
-        height: "高さ"
-        price: "価格"
-        sku: "品番"
-        weight: "重量"
-        width: "幅"
+        cost_currency: コストカレンシー
+        cost_price: 原価
+        depth: 奥行き
+        height: 高さ
+        price: 価格
+        sku: 品番
+        weight: 重量
+        width: 幅
       spree/zone:
-        description: "説明"
-        name: "名前"
+        description: 説明
+        name: 名前
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number: "列キーは0より大きい値でなければなりません。"
+              keys_should_be_positive_number: 列キーは0より大きい値でなければなりません。
             preferred_tiers:
-              should_be_hash: "ハッシュでなければなりません"
+              should_be_hash: ハッシュでなければなりません
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number: "列キーは0より大きい値でなければなりません。"
-              values_should_be_percent: "列の値は0%から100%の間でなければなりません。"
+              keys_should_be_positive_number: 列キーは0より大きい値でなければなりません。
+              values_should_be_percent: 列の値は0%から100%の間でなければなりません。
             preferred_tiers:
-              should_be_hash: "ハッシュでなければなりません"
+              should_be_hash: ハッシュでなければなりません
         spree/classification:
           attributes:
             taxon_id:
-              already_linked: "はすでに今プロダクトと連携されています。"
+              already_linked: はすでに今プロダクトと連携されています。
         spree/credit_card:
           attributes:
             base:
-              card_expired: "カードの有効期限が切れています。"
-              expiry_invalid: "カードの有効期限が不正です。"
+              card_expired: カードの有効期限が切れています。
+              expiry_invalid: カードの有効期限が不正です。
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency: "注文貨幣と一致してなければなりません。"
+              must_match_order_currency: 注文貨幣と一致してなければなりません。
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed: "は許容量より大きい値です。"
+              greater_than_allowed: は許容量より大きい値です。
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match: "一つかそれ以上の返品商品が払い戻しとして同じ商品に属されていません。"
+              return_items_order_id_does_not_match: 一つかそれ以上の返品商品が払い戻しとして同じ商品に属されていません。
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists: "は受諾されなかった返品に関連付けられませんでした。"
+              other_completed_return_item_exists: は受諾されなかった返品に関連付けられませんでした。
             reimbursement:
               cannot_be_associated_unless_accepted: "%{inventory_unit_id}はすでに返品%{return_item_id}として使われています。"
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store: "デフォルトの店を削除することはできません。"
+              cannot_destroy_default_store: デフォルトの店を削除することはできません。
       spree/page:
         body: Body
-        foreign_link: "外部URL"
+        foreign_link: 外部URL
         layout: Layout
-        meta_description: "メタ説明"
-        meta_keywords: "メタキーワード"
-        meta_title: "メタタイトル"
-        position: "位置" 
-        render_layout_as_partial: "部分的なレイアウトとして表示"
-        show_in_footer: "フッターに表示"
-        show_in_header: "ヘッダーに表示"
-        show_in_sidebar: "サイドバーに表示"
-        slug: "パス(url)"
-        title: "タイトル"
-        visible: "表示"
+        meta_description: メタ説明
+        meta_keywords: メタキーワード
+        meta_title: メタタイトル
+        position: 位置
+        render_layout_as_partial: 部分的なレイアウトとして表示
+        show_in_footer: フッターに表示
+        show_in_header: ヘッダーに表示
+        show_in_sidebar: サイドバーに表示
+        slug: パス(url)
+        title: タイトル
+        visible: 表示
     models:
       spree/address:
-        one: "住所"
-        other: "住所"
+        one: 住所
+        other: 住所
       spree/country:
-        one: "国名"
-        other: "国名"
+        one: 国名
+        other: 国名
       spree/credit_card:
-        one: "クレジットカード"
-        other: "クレジットカード"
+        one: クレジットカード
+        other: クレジットカード
       spree/customer_return:
-        one: "返品"
-        other: "返品"
+        one: 返品
+        other: 返品
       spree/inventory_unit:
-        one: "在庫品単位"
-        other: "在庫品単位"
+        one: 在庫品単位
+        other: 在庫品単位
       spree/line_item:
-        one: "品目"
-        other: "品目"
+        one: 品目
+        other: 品目
       spree/option_type:
-        one: "オプション"
-        other: "オプション"
+        one: オプション
+        other: オプション
       spree/option_value:
-        one: "オプション値"
-        other: "オプション値"
+        one: オプション値
+        other: オプション値
       spree/order:
-        one: "注文"
-        other: "注文"
+        one: 注文
+        other: 注文
       spree/payment:
-        one: "支払い"
-        other: "支払い"
+        one: 支払い
+        other: 支払い
       spree/payment_method:
-        one: "支払い方法"
-        other: "支払い方法"
+        one: 支払い方法
+        other: 支払い方法
       spree/product:
-        one: "商品"
-        other: "商品"
+        one: 商品
+        other: 商品
       spree/promotion:
-        one: "プロモーション"
-        other: "プロモーション"
+        one: プロモーション
+        other: プロモーション
       spree/promotion_category:
-        one: "プロモーションカテゴリ"
-        other: "プロモーションカテゴリ"
+        one: プロモーションカテゴリ
+        other: プロモーションカテゴリ
       spree/property:
-        one: "属性"
-        other: "属性"
+        one: 属性
+        other: 属性
       spree/prototype:
-        one: "原型"
-        other: "原型"
+        one: 原型
+        other: 原型
       spree/refund_reason:
-        one: "返金理由"
-        other: "返金理由"
+        one: 返金理由
+        other: 返金理由
       spree/reimbursement:
-        one: "払い戻し"
-        other: "払い戻し"
+        one: 払い戻し
+        other: 払い戻し
       spree/reimbursement_type:
-        one: "払い戻し種別"
-        other: "払い戻し種別"
+        one: 払い戻し種別
+        other: 払い戻し種別
       spree/return_authorization:
-        one: "返品許可"
-        other: "返品許可"
+        one: 返品許可
+        other: 返品許可
       spree/return_authorization_reason:
-        one: "返品理由"
-        other: "返品理由"
+        one: 返品理由
+        other: 返品理由
       spree/role:
-        one: "役割"
-        other: "役割"
+        one: 役割
+        other: 役割
       spree/shipment:
-        one: "配送"
-        other: "配送"
+        one: 配送
+        other: 配送
       spree/shipping_category:
-        one: "配送カテゴリ"
-        other: "配送カテゴリ"
+        one: 配送カテゴリ
+        other: 配送カテゴリ
       spree/shipping_method:
-        one: "配送方法"
-        other: "配送方法"
+        one: 配送方法
+        other: 配送方法
       spree/state:
-        one: "都道府県（州）"
-        other: "都道府県（州）"
+        one: 都道府県（州）
+        other: 都道府県（州）
       spree/state_change:
-        one: "状態変化"
-        other: "状態変化"
+        one: 状態変化
+        other: 状態変化
       spree/stock_movement:
-        one: "在庫遷移"
-        other: "在庫遷移"
+        one: 在庫遷移
+        other: 在庫遷移
       spree/stock_location:
-        one: "在庫場所"
-        other: "在庫場所"
+        one: 在庫場所
+        other: 在庫場所
       spree/stock_transfer:
-        one: "在庫移動"
-        other: "在庫移動"
+        one: 在庫移動
+        other: 在庫移動
       spree/tax_category:
-        one: "税区分"
-        other: "税区分"
+        one: 税区分
+        other: 税区分
       spree/tax_rate:
-        one: "税率"
-        other: "税率"
+        one: 税率
+        other: 税率
       spree/taxon:
-        one: "ジャンル単位"
-        other: "ジャンル単位"
+        one: ジャンル単位
+        other: ジャンル単位
       spree/taxonomy:
-        one: "ジャンルツリー"
-        other: "ジャンルツリー"
+        one: ジャンルツリー
+        other: ジャンルツリー
       spree/tracker:
-        one: "トラッカー"
-        other: "トラッカー"
+        one: トラッカー
+        other: トラッカー
       spree/user:
-        one: "ユーザー"
-        other: "ユーザー"
+        one: ユーザー
+        other: ユーザー
       spree/variant:
-        one: "種類"
-        other: "種類"
+        one: 種類
+        other: 種類
       spree/zone:
-        one: "ゾーン"
-        other: "ゾーン"
+        one: ゾーン
+        other: ゾーン
       spree/page:
-        one: "特集ページ"
-        other: "特集ページ"
+        one: 特集ページ
+        other: 特集ページ
   devise:
     confirmations:
-      confirmed: "アカウントが正常に確認されました。ログインしました。"
-      send_instructions: "数分以内に本人確認をする方法を記載したメールが届きます。"
+      confirmed: アカウントが正常に確認されました。ログインしました。
+      send_instructions: 数分以内に本人確認をする方法を記載したメールが届きます。
     failure:
-      inactive: "アカウントはまだ確認されませんでした。"
+      inactive: アカウントはまだ確認されませんでした。
       invalid: Eメールアドレスもしくはパスワードが異なります。
-      invalid_token: "無効な認証トークン。"
-      locked: "アカウントはロックされています"
-      timeout: "セッションの有効期限が切れました。続けるには再度ログインしてください。"
-      unauthenticated: "続ける前にサインインかサインアップが必要です。"
-      unconfirmed: "続ける前にアカウントの確認が必要です。"
+      invalid_token: 無効な認証トークン。
+      locked: アカウントはロックされています
+      timeout: セッションの有効期限が切れました。続けるには再度ログインしてください。
+      unauthenticated: 続ける前にサインインかサインアップが必要です。
+      unconfirmed: 続ける前にアカウントの確認が必要です。
     mailer:
       confirmation_instructions:
-        subject: "確認方法"
+        subject: 確認方法
       reset_password_instructions:
-        subject: "パスワードのリセット方法"
+        subject: パスワードのリセット方法
       unlock_instructions:
-        subject: "アンロック方法"
+        subject: アンロック方法
     oauth_callbacks:
       failure: "%{kind}から認証できませんでした。理由: %{reason}"
       success: "%{kind}からの認証に成功しました。"
     unlocks:
-      send_instructions: "アカウントのアンロック方法を記載したメールを送信しました。"
-      unlocked: "あなたのアカウントがアンロックされました。ログイン済みです。"
+      send_instructions: アカウントのアンロック方法を記載したメールを送信しました。
+      unlocked: あなたのアカウントがアンロックされました。ログイン済みです。
     user_passwords:
       user:
-        cannot_be_blank: "パスワードを入力してください。"
-        send_instructions: "パスワードのリセット方法を記載したメールを送信しました。"
-        updated: "パスワードの変更に成功しました。サインインし直してください。"
+        cannot_be_blank: パスワードを入力してください。
+        send_instructions: パスワードのリセット方法を記載したメールを送信しました。
+        updated: パスワードの変更に成功しました。サインインし直してください。
     user_registrations:
-      destroyed: "さようなら！アカウントが削除されました。再びお会いできる日が来ることを心待ちにしております。"
-      inactive_signed_up: "ログインに成功しました。 しかし%{reason}により、まだ完了はしていません。"
-      signed_up: "ログインに成功しました。"
-      updated: "アカウントの更新に成功しました。"
+      destroyed: さようなら！アカウントが削除されました。再びお会いできる日が来ることを心待ちにしております。
+      inactive_signed_up: ログインに成功しました。 しかし%{reason}により、まだ完了はしていません。
+      signed_up: ログインに成功しました。
+      updated: アカウントの更新に成功しました。
     user_sessions:
-      signed_in: "サインインに成功しました。"
-      signed_out: "サインアウトに成功しました。"
+      signed_in: サインインに成功しました。
+      signed_out: サインアウトに成功しました。
   errors:
     messages:
-      already_confirmed: "はすでに確認済みです。"
-      not_found: "見つかりませんでした。"
-      not_locked: "ロックされていません。"
+      already_confirmed: はすでに確認済みです。
+      not_found: 見つかりませんでした。
+      not_locked: ロックされていません。
       not_saved:
-        one: ! '%{resource}を保存するのに1つのエラーがありました。'
-        other: ! '%{resource}を保存するのに%{count}つのエラーがありました。'
+        one: "%{resource}を保存するのに1つのエラーがありました。"
+        other: "%{resource}を保存するのに%{count}つのエラーがありました。"
   spree:
-    abbreviation: "省略"
-    accept: "受付"
-    acceptance_errors: "受諾エラー"
-    acceptance_status: "受諾ステータス"
-    accepted: "受諾"
-    account: "アカウント"
-    account_updated: "アカウントが更新されました。"
-    action: "アクション"
+    abbreviation: 省略
+    accept: 受付
+    acceptance_errors: 受諾エラー
+    acceptance_status: 受諾ステータス
+    accepted: 受諾
+    account: アカウント
+    account_updated: アカウントが更新されました。
+    action: アクション
     actions:
-      cancel: "キャンセル"
-      continue: "続ける"
-      create: "作成"
-      destroy: "削除"
-      edit: "編集"
-      list: "リスト"
-      listing: "一覧"
-      new: "新規"
-      refund: "返金"
-      save: "保存"
-      update: "更新"
-    activate: "アクティベートする"
-    active: "有効"
-    add: "追加"
-    add_action_of_type: "次のタイプのアクションを追加する"
-    add_country: "国の追加"
-    add_coupon_code: "クーポンコードの追加"
-    add_new_header: "新規ヘッダの追加"
-    add_new_style: "新規スタイルの追加"
-    add_one: "新規追加"
-    add_option_value: "オプションの値を追加"
-    add_product: "新規商品の追加"
-    add_product_properties: "商品に属性を追加"
-    add_rule_of_type: "次のタイプのルールを追加する"
-    add_state: "都道府県（州）の追加"
-    add_stock: "ストック追加"
+      cancel: キャンセル
+      continue: 続ける
+      create: 作成
+      destroy: 削除
+      edit: 編集
+      list: リスト
+      listing: 一覧
+      new: 新規
+      refund: 返金
+      save: 保存
+      update: 更新
+    activate: アクティベートする
+    active: 有効
+    add: 追加
+    add_action_of_type: 次のタイプのアクションを追加する
+    add_country: 国の追加
+    add_coupon_code: クーポンコードの追加
+    add_new_header: 新規ヘッダの追加
+    add_new_style: 新規スタイルの追加
+    add_one: 新規追加
+    add_option_value: オプションの値を追加
+    add_product: 新規商品の追加
+    add_product_properties: 商品に属性を追加
+    add_rule_of_type: 次のタイプのルールを追加する
+    add_state: 都道府県（州）の追加
+    add_stock: ストック追加
     add_stock_management:
-    add_to_cart: "カートに追加"
-    add_variant: "変数の追加"
-    additional_item: "追加商品"
-    address: "住所"
-    address1: "住所１"
-    address2: "住所２"
-    adjustable: "調整可能"
-    adjustment: "調整（値引き・追加料金）"
-    adjustment_amount: "量"
-    adjustment_successfully_closed: "調整（値引き・追加料金）のクローズに成功しました。"
-    adjustment_successfully_opened: "調整（値引き・追加料金）の解放に成功しました。"
-    adjustment_total: "調整（値引き・追加料金）総額"
-    adjustments: "調整（値引き・追加料金）"
+    add_to_cart: カートに追加
+    add_variant: 変数の追加
+    additional_item: 追加商品
+    address: 住所
+    address1: 住所１
+    address2: 住所２
+    adjustable: 調整可能
+    adjustment: 調整（値引き・追加料金）
+    adjustment_amount: 量
+    adjustment_successfully_closed: 調整（値引き・追加料金）のクローズに成功しました。
+    adjustment_successfully_opened: 調整（値引き・追加料金）の解放に成功しました。
+    adjustment_total: 調整（値引き・追加料金）総額
+    adjustments: 調整（値引き・追加料金）
     admin:
       tab:
-        configuration: "設定"
-        option_types: "オプション"
-        orders: "注文"
-        overview: "概要"
-        products: "商品"
-        promotions: "プロモーション"
-        promotion_categories: "プロモーションカテゴリ"
-        properties: "属性"
-        prototypes: "原型"
-        reports: "レポート"
-        taxonomies: "ジャンルツリー"
-        taxons: "ジャンル単位"
-        users: "ユーザー"
-        settings: "設定"
-        general: "一般設定"
-        payments: "支払い方法"
-        areas: "ゾーン"
-        taxes: "税金"
-        checkout: "決済"
-        shipping: "配送方法"
-        stock: "在庫"
-        stock_items: "在庫品"
-        stock_transfers: "在庫移動"
+        configuration: 設定
+        option_types: オプション
+        orders: 注文
+        overview: 概要
+        products: 商品
+        promotions: プロモーション
+        promotion_categories: プロモーションカテゴリ
+        properties: 属性
+        prototypes: 原型
+        reports: レポート
+        taxonomies: ジャンルツリー
+        taxons: ジャンル単位
+        users: ユーザー
+        settings: 設定
+        general: 一般設定
+        payments: 支払い方法
+        areas: ゾーン
+        taxes: 税金
+        checkout: 決済
+        shipping: 配送方法
+        stock: 在庫
+        stock_items: 在庫品
+        stock_transfers: 在庫移動
       user:
-        account: "アカウント"
-        addresses: "住所"
-        items: "商品"
-        items_purchased: "購入した商品"
-        order_history: "発注履歴"
-        order_num: "注文 No."
-        orders: "注文"
-        user_information: "ユーザー情報"
-    administration: "管理"
-    advertise: "広告"
-    agree_to_privacy_policy: "年齢制限ポリシー"
-    agree_to_terms_of_service: "利用規約に同意する"
-    all: "全て"
-    all_adjustments_closed: "すべての調整は閉じました。"
-    all_adjustments_opened: "すべての調整を公開しました。"
-    all_departments: "全てのカテゴリ"
-    all_items_have_been_returned: "すべての商品を返しました。"
+        account: アカウント
+        addresses: 住所
+        items: 商品
+        items_purchased: 購入した商品
+        order_history: 発注履歴
+        order_num: 注文 No.
+        orders: 注文
+        user_information: ユーザー情報
+    administration: 管理
+    advertise: 広告
+    agree_to_privacy_policy: 年齢制限ポリシー
+    agree_to_terms_of_service: 利用規約に同意する
+    all: 全て
+    all_adjustments_closed: すべての調整は閉じました。
+    all_adjustments_opened: すべての調整を公開しました。
+    all_departments: 全てのカテゴリ
+    all_items_have_been_returned: すべての商品を返しました。
     already_signed_up_for_analytics:
-    alt_text: "代替のテキスト"
-    alternative_phone: "代替の電話番号"
-    amount: "金額"
-    analytics_desc_header_1: "Spree 解析"
-    analytics_desc_header_2: "Spreeダッシュボードに統合されたライブ解析"
-    analytics_desc_list_1: "販売情報をリアルタイムで取得する"
-    analytics_desc_list_2: "アカウントをアクティブにするには無料のSpreeアカウントが必要です。"
-    analytics_desc_list_3: "インストールにコードは必要ありません。"
-    analytics_desc_list_4: "すべては無料です！"
-    analytics_trackers: "Google アナリティクス"
-    and: "と"
-    approve: "承認"
-    approver: "承認者"
-    approved_at: "承認日時"
-    are_you_sure: "本当によろしいですか?"
-    are_you_sure_delete: "削除しますか?"
-    associated_adjustment_closed: "関連された調整が閉じられると、再計算しなくなります。それを開きますか？"
-    authorization_failure: "認証に失敗しました"
-    authorized: "認証しました。"
-    auto_capture: "自動キャプチャ"
-    available_on: "発売開始日・入荷日"
-    average_order_value: "平均オーダー値"
-    avs_response: "AVS レスポンス"
-    back: "戻る"
-    back_end: "バックエンド"
-    backordered: "入荷待ち"
+    alt_text: 代替のテキスト
+    alternative_phone: 代替の電話番号
+    amount: 金額
+    analytics_desc_header_1: Spree 解析
+    analytics_desc_header_2: Spreeダッシュボードに統合されたライブ解析
+    analytics_desc_list_1: 販売情報をリアルタイムで取得する
+    analytics_desc_list_2: アカウントをアクティブにするには無料のSpreeアカウントが必要です。
+    analytics_desc_list_3: インストールにコードは必要ありません。
+    analytics_desc_list_4: すべては無料です！
+    analytics_trackers: Google アナリティクス
+    and: と
+    approve: 承認
+    approver: 承認者
+    approved_at: 承認日時
+    are_you_sure: 本当によろしいですか?
+    are_you_sure_delete: 削除しますか?
+    associated_adjustment_closed: 関連された調整が閉じられると、再計算しなくなります。それを開きますか？
+    authorization_failure: 認証に失敗しました
+    authorized: 認証しました。
+    auto_capture: 自動キャプチャ
+    available_on: 発売開始日・入荷日
+    average_order_value: 平均オーダー値
+    avs_response: AVS レスポンス
+    back: 戻る
+    back_end: バックエンド
+    backordered: 入荷待ち
     back_to_resource_list: "%{resource} に戻る"
-    back_to_payment: "支払いに戻る"
-    back_to_rma_reason_list: "商品返品確認番号リストに戻る"
-    back_to_store: "ショップに戻る"
-    back_to_users_list: "ユーザー一覧に戻る"
-    backorderable: "入荷待ち可能"
-    backorderable_default: "入荷待ちデフォルト"
-    backorders_allowed: "入荷待ち許可"
-    balance_due: "未払額"
-    base_amount: "基準量"
-    base_percent: "基準%"
-    bill_address: "請求先住所"
-    billing: "決済"
-    billing_address: "請求先住所"
-    both: "両方とも"
-    calculated_reimbursements: "計算済み返品"
-    calculator: "計算方法"
-    calculator_settings_warning: "計算方法のタイプを変更する場合は、計算方法の設定を編集する前に保存してください。"
-    cancel: "キャンセル"
-    canceler: "キャンセル者"
-    canceled_at: "にキャンセル"
-    cannot_create_payment_without_payment_methods: "支払い方法が選択されていないので、支払いを行うことができません"
-    cannot_create_customer_returns: "まだこの注文は発送単位がないため、顧客返金を作成できません。"
-    cannot_create_returns: "未発送の注文品に対して返品が出来ません。注文をキャンセルし注文を作り直すか問い合わせて下さい。"
-    cannot_perform_operation: "処理出来ませんでした"
-    cannot_set_shipping_method_without_address: "顧客詳細が提供されるまで発送方法を設定できません。"
-    capture: "入金申請（キャプチャリング）"
-    capture_events: "入金イベント"
-    card_code: "カード照合値[セキュリティーコード]"
-    card_number: "カード番号"
-    card_type: "ブランド"
-    card_type_is: "カード類"
-    cart: "カート"
-    cart_subtotal: 
-      one: '小計 (1つの商品)'
-      other: '小計 (%{count}個の商品)'
-    categories: "カテゴリー"
-    category: "カテゴリー"
-    charged: "支払い済み"
+    back_to_payment: 支払いに戻る
+    back_to_rma_reason_list: 商品返品確認番号リストに戻る
+    back_to_store: ショップに戻る
+    back_to_users_list: ユーザー一覧に戻る
+    backorderable: 入荷待ち可能
+    backorderable_default: 入荷待ちデフォルト
+    backorders_allowed: 入荷待ち許可
+    balance_due: 未払額
+    base_amount: 基準量
+    base_percent: 基準%
+    bill_address: 請求先住所
+    billing: 決済
+    billing_address: 請求先住所
+    both: 両方とも
+    calculated_reimbursements: 計算済み返品
+    calculator: 計算方法
+    calculator_settings_warning: 計算方法のタイプを変更する場合は、計算方法の設定を編集する前に保存してください。
+    cancel: キャンセル
+    canceler: キャンセル者
+    canceled_at: にキャンセル
+    cannot_create_payment_without_payment_methods: 支払い方法が選択されていないので、支払いを行うことができません
+    cannot_create_customer_returns: まだこの注文は発送単位がないため、顧客返金を作成できません。
+    cannot_create_returns: 未発送の注文品に対して返品が出来ません。注文をキャンセルし注文を作り直すか問い合わせて下さい。
+    cannot_perform_operation: 処理出来ませんでした
+    cannot_set_shipping_method_without_address: 顧客詳細が提供されるまで発送方法を設定できません。
+    capture: 入金申請（キャプチャリング）
+    capture_events: 入金イベント
+    card_code: カード照合値[セキュリティーコード]
+    card_number: カード番号
+    card_type: ブランド
+    card_type_is: カード類
+    cart: カート
+    cart_subtotal:
+      one: 小計 (1つの商品)
+      other: 小計 (%{count}個の商品)
+    categories: カテゴリー
+    category: カテゴリー
+    charged: 支払い済み
     check_for_spree_alerts: Spreeアラートの確認
-    checkout: "レジに進む"
-    choose_a_customer: "顧客の選択"
-    choose_a_taxon_to_sort_products_for: "商品を整列するためにジャンル単位を選択"
-    choose_currency: "通貨の選択"
-    choose_dashboard_locale: "言語の選択"
+    checkout: レジに進む
+    choose_a_customer: 顧客の選択
+    choose_a_taxon_to_sort_products_for: 商品を整列するためにジャンル単位を選択
+    choose_currency: 通貨の選択
+    choose_dashboard_locale: 言語の選択
     choose_location:
-    city: "市区町村"
-    clear_cache: "キャッシュを消去"
-    clear_cache_ok: "キャッシュを消去しました。"
-    clear_cache_warning: "キャッシュのクリアはあなたの店舗のパフォーマンスを一時的に下げます。"
-    click_and_drag_on_the_products_to_sort_them: "整列するには小hんをドラッグ＆ドロップしてください。"
-    clone: "複製"
-    close: "閉じる"
-    close_all_adjustments: "すべての調整を閉じる"
-    code: "コード"
-    company: "会社"
-    complete: "完了"
-    configuration: "設定"
-    configurations: "設定"
-    confirm: "確認する"
-    confirm_delete: "削除を確認"
-    confirm_password: "パスワードの確認"
-    continue: "続ける"
-    continue_shopping: "ショッピングを続ける"
-    cost_currency: "通貨"
-    cost_price: "原価"
-    could_not_connect_to_jirafe: "データをシンクするためにJirafeを繋ぐことができませんでした。後で自動的にリトライします。"
-    could_not_create_customer_return: "顧客返品を作成できませんでした。"
-    could_not_create_stock_movement: "在庫移動を保存するのに問題が発生しました。後でリトライしてください。"
-    count_on_hand: "手計算"
-    countries: "国"
-    country: "国"
-    country_based: "国による区別"
-    country_name: "名前"
+    city: 市区町村
+    clear_cache: キャッシュを消去
+    clear_cache_ok: キャッシュを消去しました。
+    clear_cache_warning: キャッシュのクリアはあなたの店舗のパフォーマンスを一時的に下げます。
+    click_and_drag_on_the_products_to_sort_them: 整列するには小hんをドラッグ＆ドロップしてください。
+    clone: 複製
+    close: 閉じる
+    close_all_adjustments: すべての調整を閉じる
+    code: コード
+    company: 会社
+    complete: 完了
+    configuration: 設定
+    configurations: 設定
+    confirm: 確認する
+    confirm_delete: 削除を確認
+    confirm_password: パスワードの確認
+    continue: 続ける
+    continue_shopping: ショッピングを続ける
+    cost_currency: 通貨
+    cost_price: 原価
+    could_not_connect_to_jirafe: データをシンクするためにJirafeを繋ぐことができませんでした。後で自動的にリトライします。
+    could_not_create_customer_return: 顧客返品を作成できませんでした。
+    could_not_create_stock_movement: 在庫移動を保存するのに問題が発生しました。後でリトライしてください。
+    count_on_hand: 手計算
+    countries: 国
+    country: 国
+    country_based: 国による区別
+    country_name: 名前
     country_names:
-      CA: "カナダ"
-      FRA: "フランス"
-      ITA: "イタリア"
-      US: "アメリカ"
-    coupon: "クーポン"
-    coupon_code: "クーポンコード"
-    coupon_code_already_applied: "そのクーポンはすでにこの注文に適用されています。"
-    coupon_code_applied: "クーポンコードが適応されました。"
-    coupon_code_better_exists: "前回適用したクーポンコードの方がよりよい取引となります。"
-    coupon_code_expired: "クーポンコードは期限切れです。"
-    coupon_code_max_usage: "クーポンコードの利用制限を超えました。"
-    coupon_code_not_eligible: "このクーポンコードはこの注文では適用できません。"
-    coupon_code_not_found: "指定のクーポンコードが見つかりませんでした。"
-    coupon_code_unknown_error: "このクーポンコードは現時点で利用することができません。"
-    create: "作成"
-    create_a_new_account: "新規アカウント作成"
-    create_new_order: "新規注文作成"
-    create_reimbursement: "返品作成"
-    created_at: "作成日時"
-    credit: "債権"
-    credit_card: "クレジットカード"
-    credit_cards: "クレジットカード"
-    credit_owed: "過払い額"
-    credits: "債権"
-    currency: "通貨"
-    currency_settings: "通貨の設定"
-    current: "現在"
-    current_promotion_usage: ! '現在の使用方法: %{count}'
-    customer: "お客様"
-    customer_details: "お客様詳細情報"
-    customer_details_updated: "お客様詳細情報が更新されました。"
-    customer_return: "顧客返品"
-    customer_returns: "顧客返品"
-    customer_search: "お客様の検索"
-    cut: "カット"
-    cvv_response: "CVV の返答"
+      CA: カナダ
+      FRA: フランス
+      ITA: イタリア
+      US: アメリカ
+    coupon: クーポン
+    coupon_code: クーポンコード
+    coupon_code_already_applied: そのクーポンはすでにこの注文に適用されています。
+    coupon_code_applied: クーポンコードが適応されました。
+    coupon_code_better_exists: 前回適用したクーポンコードの方がよりよい取引となります。
+    coupon_code_expired: クーポンコードは期限切れです。
+    coupon_code_max_usage: クーポンコードの利用制限を超えました。
+    coupon_code_not_eligible: このクーポンコードはこの注文では適用できません。
+    coupon_code_not_found: 指定のクーポンコードが見つかりませんでした。
+    coupon_code_unknown_error: このクーポンコードは現時点で利用することができません。
+    create: 作成
+    create_a_new_account: 新規アカウント作成
+    create_new_order: 新規注文作成
+    create_reimbursement: 返品作成
+    created_at: 作成日時
+    credit: 債権
+    credit_card: クレジットカード
+    credit_cards: クレジットカード
+    credit_owed: 過払い額
+    credits: 債権
+    currency: 通貨
+    currency_settings: 通貨の設定
+    current: 現在
+    current_promotion_usage: '現在の使用方法: %{count}'
+    customer: お客様
+    customer_details: お客様詳細情報
+    customer_details_updated: お客様詳細情報が更新されました。
+    customer_return: 顧客返品
+    customer_returns: 顧客返品
+    customer_search: お客様の検索
+    cut: カット
+    cvv_response: CVV の返答
     dash:
       jirafe:
-        app_id: "App ID"
-        app_token: "App Token"
-        currently_unavailable: "Jirafe は現在利用不可です。"
+        app_id: App ID
+        app_token: App Token
+        currently_unavailable: Jirafe は現在利用不可です。
         explanation:
         header:
         site_id:
         token:
       jirafe_settings_updated:
-    date: "日時"
-    date_completed: "完了日"
+    date: 日時
+    date_completed: 完了日
     date_picker:
       first_day: 0
-      format: ! '%Y/%m/%d'
+      format: "%Y/%m/%d"
       js_format: yy/mm/dd
-    date_range: "日範囲"
-    default: "初期設定"
+    date_range: 日範囲
+    default: 初期設定
     default_refund_amount:
-    default_tax: "デフォルトの税"
-    default_tax_zone: "デフォルトのタックスゾーン"
-    delete: "削除"
-    delete_from_taxon: "ジャンル単位から削除"
-    deleted_variants_present: "注文の商品のいくつかが既に購入不可となっています。"
-    delivery: "配送/お届け"
-    depth: "奥行き"
-    details: "詳細"
-    description: "説明"
-    destination: "目的地"
-    destroy: "破壊する"
-    discount_amount: "割引額"
-    dismiss_banner: "いいえ。結構です！興味ありません。再びこのメッセージを表示しないでください。"
-    display: "表示"
-    doesnt_track_inventory: "在庫をトラッキングしません。"
-    edit: "編集"
+    default_tax: デフォルトの税
+    default_tax_zone: デフォルトのタックスゾーン
+    delete: 削除
+    delete_from_taxon: ジャンル単位から削除
+    deleted_variants_present: 注文の商品のいくつかが既に購入不可となっています。
+    delivery: 配送/お届け
+    depth: 奥行き
+    details: 詳細
+    description: 説明
+    destination: 目的地
+    destroy: 破壊する
+    discount_amount: 割引額
+    dismiss_banner: いいえ。結構です！興味ありません。再びこのメッセージを表示しないでください。
+    display: 表示
+    doesnt_track_inventory: 在庫をトラッキングしません。
+    edit: 編集
     editing_country:
     editing_adjustment_reason:
     editing_option_type:
     editing_payment_method:
-    editing_product: "商品の編集"
+    editing_product: 商品の編集
     editing_promotion:
     editing_promotion_category:
     editing_property:
@@ -661,7 +661,7 @@ ja:
     editing_reimbursement:
     editing_reimbursement_type:
     editing_resource: "%{resource}を編集"
-    editing_rma_reason: "RMA理由を編集"
+    editing_rma_reason: RMA理由を編集
     editing_shipping_category:
     editing_shipping_method:
     editing_state:
@@ -671,774 +671,774 @@ ja:
     editing_tax_category:
     editing_tax_rate:
     editing_tracker:
-    editing_user: "ユーザーの編集"
-    editing_zone: "ゾーンの編集"
+    editing_user: ユーザーの編集
+    editing_zone: ゾーンの編集
     eligibility_errors:
       messages:
-        has_excluded_product: "カート内に適用済みのクーポンコードを妨げる商品が含まれています。"
+        has_excluded_product: カート内に適用済みのクーポンコードを妨げる商品が含まれています。
         item_total_less_than: "%{amount}個より少ない注文でこのクーポンコードを適用することはできません。"
         item_total_less_than_or_equal: "%{amount}個以下の注文でこのクーポンコードを適用することはできません。"
         item_total_more_than: "%{amount}個より多い注文にこのクーポンコードを適用することはできません。"
         item_total_more_than_or_equal: "%{amount}個以上の注文にこのクーポンコードを適用することはできません。"
-        limit_once_per_user: "このクーポンコードは１ユーザーにつき１回までしか利用できません。"
-        missing_product: "このクーポンコードはあなたのカート内に必要なすべての商品がないため適用できません。"
-        missing_taxon: "クーポンコードを適用する前に、必要なすべてのジャンルを商品に追加する必要があります。"
-        no_applicable_products: "このクーポンコードを適用する前に、必要な商品を追加する必要があります。"
-        no_matching_taxons: "このクーポンコードを適用する前に必要なジャンルから商品を追加する必要があります。"
-        no_user_or_email_specified: "このクーポンコードを適用する前にログインもしくはメールアドレスを提供する必要があります。"
-        no_user_specified: "このクーポンコードを適用する前にログインする必要があります。"
-        not_first_order: "このクーポンコードは最初の注文にのみ適用できます。"
+        limit_once_per_user: このクーポンコードは１ユーザーにつき１回までしか利用できません。
+        missing_product: このクーポンコードはあなたのカート内に必要なすべての商品がないため適用できません。
+        missing_taxon: クーポンコードを適用する前に、必要なすべてのジャンルを商品に追加する必要があります。
+        no_applicable_products: このクーポンコードを適用する前に、必要な商品を追加する必要があります。
+        no_matching_taxons: このクーポンコードを適用する前に必要なジャンルから商品を追加する必要があります。
+        no_user_or_email_specified: このクーポンコードを適用する前にログインもしくはメールアドレスを提供する必要があります。
+        no_user_specified: このクーポンコードを適用する前にログインする必要があります。
+        not_first_order: このクーポンコードは最初の注文にのみ適用できます。
     email: Eメール
-    empty: "空"
-    empty_cart: "カートを空にする"
-    enable_mail_delivery: "メールによるお知らせを有効にする/許可する"
-    end: "終わり"
-    ending_in: "末尾の数字"
-    error: "エラー"
+    empty: 空
+    empty_cart: カートを空にする
+    enable_mail_delivery: メールによるお知らせを有効にする/許可する
+    end: 終わり
+    ending_in: 末尾の数字
+    error: エラー
     errors:
       messages:
-        could_not_create_taxon: "ジャンル単位の作成が失敗しました"
-        no_shipping_methods_available: "この場所へ発送可能な配送方法がありませんでした。別の住所を設定するか問い合わせして下さい。"
+        could_not_create_taxon: ジャンル単位の作成が失敗しました
+        no_shipping_methods_available: この場所へ発送可能な配送方法がありませんでした。別の住所を設定するか問い合わせして下さい。
     errors_prohibited_this_record_from_being_saved:
-      one: "エラーにより登録出来ませんでした。"
+      one: エラーにより登録出来ませんでした。
       other: "%{count}つのエラーにより登録出来ませんでした。"
-    event: "イベント"
+    event: イベント
     events:
       spree:
         cart:
-          add: "カートに入れる"
+          add: カートに入れる
         checkout:
-          coupon_code_added: "クーポンコード追加"
+          coupon_code_added: クーポンコード追加
         content:
-          visited: "静的コンテンツページの訪問"
+          visited: 静的コンテンツページの訪問
         order:
-          contents_changed: "注文内容の変更"
-        page_view: "静的ページを見る"
+          contents_changed: 注文内容の変更
+        page_view: 静的ページを見る
         user:
-          signup: "ユーザー登録"
+          signup: ユーザー登録
     exceptions:
-      count_on_hand_setter: "手動で手計算をセットできません。それはrecalculate_count_on_handコールバックで自動的にセットされます。`update_column(:count_on_hand, value)`を代わりに利用してください。"
-    exchange_for: "に変換"
-    expedited_exchanges_warning: "指定したどんな変換も保存後すぐに顧客に反映されます。もし顧客が元の商品を%{days_window}日以内に返さなかった場合、顧客はすべての量の商品に決済されます。"
+      count_on_hand_setter: 手動で手計算をセットできません。それはrecalculate_count_on_handコールバックで自動的にセットされます。`update_column(:count_on_hand,
+        value)`を代わりに利用してください。
+    exchange_for: に変換
+    expedited_exchanges_warning: 指定したどんな変換も保存後すぐに顧客に反映されます。もし顧客が元の商品を%{days_window}日以内に返さなかった場合、顧客はすべての量の商品に決済されます。
     excl: excl.
-    expiration: "有効期限"
-    extension: "拡張"
-    existing_shipments: "現在の発送"
-    failed_payment_attempts: "支払いに失敗"
-    filename: "ファイル名"
-    fill_in_customer_info: "顧客情報を埋めてください。"
-    filter: "検索"
-    filter_results: "検索結果"
-    finalize: "確定"
-    find_a_taxon: "ジャンル単位を見つける"
-    finalized: "確定済み"
-    first_item: "一品目の値段"
-    first_name: "名前（名）"
-    first_name_begins_with: "名前（名）が以下の文字列で始まる"
-    flat_percent: "定率"
-    flat_rate_per_order: "定格(一注文につき)"
-    flexible_rate: "変動料金"
-    forgot_password: "パスワードを忘れた方"
-    free_shipping: "配送料無料"
+    expiration: 有効期限
+    extension: 拡張
+    existing_shipments: 現在の発送
+    failed_payment_attempts: 支払いに失敗
+    filename: ファイル名
+    fill_in_customer_info: 顧客情報を埋めてください。
+    filter: 検索
+    filter_results: 検索結果
+    finalize: 確定
+    find_a_taxon: ジャンル単位を見つける
+    finalized: 確定済み
+    first_item: 一品目の値段
+    first_name: 名前（名）
+    first_name_begins_with: 名前（名）が以下の文字列で始まる
+    flat_percent: 定率
+    flat_rate_per_order: 定格(一注文につき)
+    flexible_rate: 変動料金
+    forgot_password: パスワードを忘れた方
+    free_shipping: 配送料無料
     free_shipping_amount:
-    front_end: "フロントエンド"
-    gateway: "ゲートウェイ"
-    gateway_error: "ゲートウェイエラー"
-    general: "一般"
-    general_settings: "一般設定"
-    google_analytics: "Googleアナリティクス"
-    google_analytics_id: "Google アナリティクス ID"
-    guest_checkout: "ゲスト注文"
-    guest_user_account: "登録せずにゲストとして注文する"
-    has_no_shipped_units: "の発送済みユニットはありません"
-    height: "高さ"
-    home: "ホーム"
+    front_end: フロントエンド
+    gateway: ゲートウェイ
+    gateway_error: ゲートウェイエラー
+    general: 一般
+    general_settings: 一般設定
+    google_analytics: Googleアナリティクス
+    google_analytics_id: Google アナリティクス ID
+    guest_checkout: ゲスト注文
+    guest_user_account: 登録せずにゲストとして注文する
+    has_no_shipped_units: の発送済みユニットはありません
+    height: 高さ
+    home: ホーム
     i18n:
-      available_locales: "可能なローケル"
-      fields: "フィールド"
-      language: "言語"
-      locales_displayed_on_frontend_select_box: "フロントのセレクトボックスに設定した言語が表示されます"
-      localization_settings: "言語設定"
-      only_complete: "不完全のみ"
-      only_incomplete: "完全のみ"
-      select_locale: "言語の選択"
-      show_only: "だけ表示"
-      supported_locales: "サポート済み言語"
-      this_file_language: "日本語 (ja-JP)"
-      translations: "翻訳"
-    icon: "アイコン"
-    image: "画像"
-    images: "画像"
-    implement_eligible_for_return: 
+      available_locales: 可能なローケル
+      fields: フィールド
+      language: 言語
+      locales_displayed_on_frontend_select_box: フロントのセレクトボックスに設定した言語が表示されます
+      localization_settings: 言語設定
+      only_complete: 不完全のみ
+      only_incomplete: 完全のみ
+      select_locale: 言語の選択
+      show_only: だけ表示
+      supported_locales: サポート済み言語
+      this_file_language: 日本語 (ja-JP)
+      translations: 翻訳
+    icon: アイコン
+    image: 画像
+    images: 画像
+    implement_eligible_for_return:
     implement_requires_manual_intervention:
-    inactive: "非活性"
-    incl: 
-    included_in_price: "価格に含まれる"
-    included_price_validation: "はデフォルトのタックスゾーンを設定しない限り選択できません。"
-    incomplete: "不完全"
-    info_product_has_multiple_skus: "この商品は%{count}個あります:"
+    inactive: 非活性
+    incl:
+    included_in_price: 価格に含まれる
+    included_price_validation: はデフォルトのタックスゾーンを設定しない限り選択できません。
+    incomplete: 不完全
+    info_product_has_multiple_skus: 'この商品は%{count}個あります:'
     info_number_of_skus_not_shown:
-      one: "ともう一つ"
-      other: "と %{count}個"
-    instructions_to_reset_password: "下のフォームを入力してからパスワードの再設定方法の説明がメールで送信されます。"
-    insufficient_stock: "在庫が十分ではありません。残り%{on_hand}個です。"
-    insufficient_stock_lines_present: "いくつかの注文商品のが不十分です。"
-    intercept_email_address: "置き換え用のメールアドレス"
-    intercept_email_instructions: "メールの宛先をこのアドレスで置き換えます。"
-    internal_name: "内部の名前"
-    invalid_credit_card: "不正なクレジットカード"
-    invalid_exchange_variant: "不正な両替型"
-    invalid_payment_provider: "不正な支払いプロバイダー"
-    invalid_promotion_action: "不正なプロモーションアクション"
-    invalid_promotion_rule: "不正なプロモーションルール"
-    inventory: "在庫"
-    inventory_adjustment: "在庫調整"
-    inventory_error_flash_for_insufficient_quantity: "カート内のアイテムが販売不可となりました。"
-    inventory_state: "在庫状態"
-    is_not_available_to_shipment_address: "はこの配達先では発送出来ません。"
+      one: ともう一つ
+      other: と %{count}個
+    instructions_to_reset_password: 下のフォームを入力してからパスワードの再設定方法の説明がメールで送信されます。
+    insufficient_stock: 在庫が十分ではありません。残り%{on_hand}個です。
+    insufficient_stock_lines_present: いくつかの注文商品のが不十分です。
+    intercept_email_address: 置き換え用のメールアドレス
+    intercept_email_instructions: メールの宛先をこのアドレスで置き換えます。
+    internal_name: 内部の名前
+    invalid_credit_card: 不正なクレジットカード
+    invalid_exchange_variant: 不正な両替型
+    invalid_payment_provider: 不正な支払いプロバイダー
+    invalid_promotion_action: 不正なプロモーションアクション
+    invalid_promotion_rule: 不正なプロモーションルール
+    inventory: 在庫
+    inventory_adjustment: 在庫調整
+    inventory_error_flash_for_insufficient_quantity: カート内のアイテムが販売不可となりました。
+    inventory_state: 在庫状態
+    is_not_available_to_shipment_address: はこの配達先では発送出来ません。
     iso_name: ISO名
-    item: "アイテム"
-    item_description: "アイテム説明"
-    item_total: "合計"
+    item: アイテム
+    item_description: アイテム説明
+    item_total: 合計
     item_total_rule:
       operators:
-        gt: "より大きい"
-        gte: "以上"
-        lt: "より小さい"
-        lte: "以下"
-    items_cannot_be_shipped: "選択した商品の発送料の計算ができませんでした。"
-    items_in_rmas: "返品認証"
-    items_reimbursed: "返品された商品"
-    items_to_be_reimbursed: "商品は返品されました"
+        gt: より大きい
+        gte: 以上
+        lt: より小さい
+        lte: 以下
+    items_cannot_be_shipped: 選択した商品の発送料の計算ができませんでした。
+    items_in_rmas: 返品認証
+    items_reimbursed: 返品された商品
+    items_to_be_reimbursed: 商品は返品されました
     jirafe:
     landing_page_rule:
-      path: "パス"
-    last_name: "名前（姓）"
-    last_name_begins_with: "名前（姓）が以下の文字列で始まる"
-    learn_more: "もっと詳しく"
+      path: パス
+    last_name: 名前（姓）
+    last_name_begins_with: 名前（姓）が以下の文字列で始まる
+    learn_more: もっと詳しく
     lifetime_stats:
-    line_item_adjustments: "商品調整"
-    list: "リスト"
-    listing_countries: "国一覧"
-    listing_orders: "注文一覧"
-    listing_products: "商品一覧"
-    listing_reports: "レポート一覧"
-    listing_tax_categories: "税金カテゴリー一覧"
-    listing_users: "ユーザー一覧"
-    loading: "読み込み中"
-    locale_changed: "ロケールを変更しました"
-    location: "位置"
-    lock: "ロック"
-    log_entries: "ログエントリー"
-    logs: "ログ"
-    logged_in_as: "ログイン"
-    logged_in_succesfully: "ログインに成功しました"
-    logged_out: "ログアウトしました。"
-    login: "ログイン"
-    login_as_existing: "アカウント持ちのお客様ログイン"
-    login_failed: "ログイン認証失敗"
-    login_name: "ログイン名"
-    logout: "ログアウト"
-    look_for_similar_items: "似た商品を探す"
-    make_refund: "返金する"
-    make_sure_the_above_reimbursement_amount_is_correct: "上記の返品量が正しいことを確認してください。"
-    manage_promotion_categories: "プロモーションカテゴリの管理"
-    manage_stock: "在庫管理"
-    manage_variants: "型の管理"
-    manual_intervention_required: "主導介入が必要"
-    master_price: "定価"
+    line_item_adjustments: 商品調整
+    list: リスト
+    listing_countries: 国一覧
+    listing_orders: 注文一覧
+    listing_products: 商品一覧
+    listing_reports: レポート一覧
+    listing_tax_categories: 税金カテゴリー一覧
+    listing_users: ユーザー一覧
+    loading: 読み込み中
+    locale_changed: ロケールを変更しました
+    location: 位置
+    lock: ロック
+    log_entries: ログエントリー
+    logs: ログ
+    logged_in_as: ログイン
+    logged_in_succesfully: ログインに成功しました
+    logged_out: ログアウトしました。
+    login: ログイン
+    login_as_existing: アカウント持ちのお客様ログイン
+    login_failed: ログイン認証失敗
+    login_name: ログイン名
+    logout: ログアウト
+    look_for_similar_items: 似た商品を探す
+    make_refund: 返金する
+    make_sure_the_above_reimbursement_amount_is_correct: 上記の返品量が正しいことを確認してください。
+    manage_promotion_categories: プロモーションカテゴリの管理
+    manage_stock: 在庫管理
+    manage_variants: 型の管理
+    manual_intervention_required: 主導介入が必要
+    master_price: 定価
     match_choices:
-      all: "すべて"
-      none: "なし"
-    max_items: "商品の数の最大限"
-    member_since: 
-    memo: "メモ"
-    meta_description: "メタ情報説明"
-    meta_keywords: "メタキーワード"
-    meta_title: "メタタイトル"
-    metadata: "メタデータ"
-    minimal_amount: "最低額"
-    month: "月"
-    more: "さらに"
-    move_stock_between_locations: "位置間の在庫移動"
-    my_account: "アカウント情報"
-    my_orders: "注文情報"
-    name: "名称"
-    name_on_card: "カード名義"
-    name_or_sku: "品名もしくは品番"
-    new: "新規"
-    new_adjustment: "新規の値引き・追加請求"
-    new_customer: "新規顧客"
-    new_customer_return: "新規顧客返品"
-    new_country: "新規国"
-    new_image: "新規画像"
-    new_option_type: "新規オプション"
-    new_order: "新規注文"
-    new_order_completed: "新規注文作成完了"
-    new_payment: "新規の支払い"
-    new_payment_method: "支払い方法を追加"
-    new_product: "新規商品"
-    new_promotion: "新規プロモーション"
-    new_promotion_category: "新規プロモーションカテゴリ"
-    new_property: "新規属性"
-    new_prototype: "新規原型"
-    new_refund: "新規返金"
-    new_refund_reason: "新規返金理由"
-    new_rma_reason: "新規RMA理由"
-    new_return_authorization: "新規返品依頼"
-    new_role: "新規役割"
-    new_shipping_category: "新規配送カテゴリー"
-    new_shipping_method: "新規配送方法"
+      all: すべて
+      none: なし
+    max_items: 商品の数の最大限
+    member_since:
+    memo: メモ
+    meta_description: メタ情報説明
+    meta_keywords: メタキーワード
+    meta_title: メタタイトル
+    metadata: メタデータ
+    minimal_amount: 最低額
+    month: 月
+    more: さらに
+    move_stock_between_locations: 位置間の在庫移動
+    my_account: アカウント情報
+    my_orders: 注文情報
+    name: 名称
+    name_on_card: カード名義
+    name_or_sku: 品名もしくは品番
+    new: 新規
+    new_adjustment: 新規の値引き・追加請求
+    new_customer: 新規顧客
+    new_customer_return: 新規顧客返品
+    new_country: 新規国
+    new_image: 新規画像
+    new_option_type: 新規オプション
+    new_order: 新規注文
+    new_order_completed: 新規注文作成完了
+    new_payment: 新規の支払い
+    new_payment_method: 支払い方法を追加
+    new_product: 新規商品
+    new_promotion: 新規プロモーション
+    new_promotion_category: 新規プロモーションカテゴリ
+    new_property: 新規属性
+    new_prototype: 新規原型
+    new_refund: 新規返金
+    new_refund_reason: 新規返金理由
+    new_rma_reason: 新規RMA理由
+    new_return_authorization: 新規返品依頼
+    new_role: 新規役割
+    new_shipping_category: 新規配送カテゴリー
+    new_shipping_method: 新規配送方法
     new_shipment_at_location:
-    new_state: "新規都道府県（州）"
-    new_stock_location: "新規在庫場所"
-    new_stock_movement: "新規在庫移動"
-    new_stock_transfer: "新規転移"
-    new_tax_category: "新規税金カテゴリー"
-    new_tax_rate: "新規税率"
-    new_taxon: "新規ジャンル単位"
-    new_taxonomy: "新規ジャンルツリー"
-    new_tracker: "新規アナリティクス"
-    new_user: "新規ユーザー"
-    new_variant: "新規種類"
-    new_zone: "新規ゾーン"
-    next: "次へ"
-    no_actions_added: "アクションなし"
-    no_payment_found: "支払いなし"
-    no_pending_payments: "延滞なし"
-    no_products_found: "商品が見付かりませんでした。"
-    no_results: "検索結果がありませんでした。"
-    no_rules_added: "ルールが追加されていません"
+    new_state: 新規都道府県（州）
+    new_stock_location: 新規在庫場所
+    new_stock_movement: 新規在庫移動
+    new_stock_transfer: 新規転移
+    new_tax_category: 新規税金カテゴリー
+    new_tax_rate: 新規税率
+    new_taxon: 新規ジャンル単位
+    new_taxonomy: 新規ジャンルツリー
+    new_tracker: 新規アナリティクス
+    new_user: 新規ユーザー
+    new_variant: 新規種類
+    new_zone: 新規ゾーン
+    next: 次へ
+    no_actions_added: アクションなし
+    no_payment_found: 支払いなし
+    no_pending_payments: 延滞なし
+    no_products_found: 商品が見付かりませんでした。
+    no_results: 検索結果がありませんでした。
+    no_rules_added: ルールが追加されていません
     no_resource_found: "%{resource}が見つかりませんでした。"
-    no_returns_found: "返品がありません。"
-    no_shipping_method_selected: "配送方法が選択されていません。"
-    no_state_changes: "まだ状態変化がありません。"
-    no_tracking_present: "トラッキング詳細が提供されていません。"
-    none: "空です"
-    none_selected: "選択なし"
-    normal_amount: "通常価格"
-    not: "非"
+    no_returns_found: 返品がありません。
+    no_shipping_method_selected: 配送方法が選択されていません。
+    no_state_changes: まだ状態変化がありません。
+    no_tracking_present: トラッキング詳細が提供されていません。
+    none: 空です
+    none_selected: 選択なし
+    normal_amount: 通常価格
+    not: 非
     not_available: N/A
-    not_enough_stock: "この転移を完了させるのに十分な在庫がありません。"
+    not_enough_stock: この転移を完了させるのに十分な在庫がありません。
     not_found: "%{resource}が見つかりません"
-    note: "ノート"
+    note: ノート
     notice_messages:
-      product_cloned: "商品を複製しました"
-      product_deleted: "商品を削除しました"
-      product_not_cloned: "商品を複製することが出来ませんでした"
-      product_not_deleted: "商品を削除することが出来ませんでした"
-      variant_deleted: "種類を削除しました"
-      variant_not_deleted: "種類を削除することが出来ませんでした"
+      product_cloned: 商品を複製しました
+      product_deleted: 商品を削除しました
+      product_not_cloned: 商品を複製することが出来ませんでした
+      product_not_deleted: 商品を削除することが出来ませんでした
+      variant_deleted: 種類を削除しました
+      variant_not_deleted: 種類を削除することが出来ませんでした
     num_orders:
-    on_hand: "入荷数"
-    open: "公開"
-    open_all_adjustments: "すべての調整を開く"
-    option_type: "オプション"
-    option_type_placeholder: "プレイスホルダ"
-    option_types: "オプション"
-    option_value: "オプション値"
-    option_values: "オプション値"
-    optional: "オプショナル"
-    options: "オプション"
-    or: "もしくは"
+    on_hand: 入荷数
+    open: 公開
+    open_all_adjustments: すべての調整を開く
+    option_type: オプション
+    option_type_placeholder: プレイスホルダ
+    option_types: オプション
+    option_value: オプション値
+    option_values: オプション値
+    optional: オプショナル
+    options: オプション
+    or: もしくは
     or_over_price: "%{price}以上"
-    order: "注文"
-    order_adjustments: "注文調整"
-    order_already_updated: "その注文は既に更新されています。"
-    order_approved: "注文の承認"
-    order_canceled: "注文のキャンセル"
-    order_details: "注文詳細"
-    order_email_resent: "注文詳細メールを再送信しました"
-    order_information: "注文情報"
-    order_line_items: "品目"
+    order: 注文
+    order_adjustments: 注文調整
+    order_already_updated: その注文は既に更新されています。
+    order_approved: 注文の承認
+    order_canceled: 注文のキャンセル
+    order_details: 注文詳細
+    order_email_resent: 注文詳細メールを再送信しました
+    order_information: 注文情報
+    order_line_items: 品目
     order_mailer:
       cancel_email:
-        dear_customer: "お客様へ"
-        instructions: "注文はキャンセルされました。以下のキャンセル情報を記録として残しておくよう御願い致します。"
-        order_summary_canceled: "注文概要 [キャンセル済み]"
-        subject: "注文のキャンセル"
-        subtotal: "小計: "
-        total: "注文合計: "
+        dear_customer: お客様へ
+        instructions: 注文はキャンセルされました。以下のキャンセル情報を記録として残しておくよう御願い致します。
+        order_summary_canceled: 注文概要 [キャンセル済み]
+        subject: 注文のキャンセル
+        subtotal: '小計: '
+        total: '注文合計: '
       confirm_email:
-        dear_customer: "お客様へ"
-        instructions: "以下の注文情報を記録として残していただくようお願い申し上げます。"
-        order_summary: "注文概要"
-        subject: "注文確認"
-        subtotal: "小計:"
-        thanks: "ご利用ありがとうございました。"
-        total: "合計: "
-    order_not_found: "注文を見つけることができませんでした。リトライしていただくようお願いいたします。"
-    order_number: "注文 %{number}"
-    order_processed_successfully: "注文が完了しました。"
-    order_resumed: "注文の再開"
+        dear_customer: お客様へ
+        instructions: 以下の注文情報を記録として残していただくようお願い申し上げます。
+        order_summary: 注文概要
+        subject: 注文確認
+        subtotal: '小計:'
+        thanks: ご利用ありがとうございました。
+        total: '合計: '
+    order_not_found: 注文を見つけることができませんでした。リトライしていただくようお願いいたします。
+    order_number: 注文 %{number}
+    order_processed_successfully: 注文が完了しました。
+    order_resumed: 注文の再開
     order_state:
-      address: "住所"
-      awaiting_return: "返品待ち"
-      canceled: "キャンセル"
-      cart: "カート"
-      complete: "完了"
-      confirm: "確認"
-      considered_risky: "考えられるリスク"
-      delivery: "配送"
-      payment: "支払い"
-      resumed: "再開"
-      returned: "返品済み"
-    order_summary: "注文サマリー"
-    order_sure_want_to: "本当にこの注文を%{event}しますか？"
-    order_total: "合計"
-    order_updated: "注文内容が更新されました。"
-    orders: "注文"
-    other_items_in_other: "注文の他のアイテム"
-    out_of_stock: "在庫が品切れです"
-    overview: "概要"
-    package_from: "パッケージ元"
+      address: 住所
+      awaiting_return: 返品待ち
+      canceled: キャンセル
+      cart: カート
+      complete: 完了
+      confirm: 確認
+      considered_risky: 考えられるリスク
+      delivery: 配送
+      payment: 支払い
+      resumed: 再開
+      returned: 返品済み
+    order_summary: 注文サマリー
+    order_sure_want_to: 本当にこの注文を%{event}しますか？
+    order_total: 合計
+    order_updated: 注文内容が更新されました。
+    orders: 注文
+    other_items_in_other: 注文の他のアイテム
+    out_of_stock: 在庫が品切れです
+    overview: 概要
+    package_from: パッケージ元
     pagination:
-      next_page: "次のページ »"
+      next_page: 次のページ »
       previous_page: "« 前のページ"
       truncate: "…"
-    password: "パスワード"
+    password: パスワード
     paste: Paste
-    path: "パス"
-    pay: "支払い"
-    payment: "支払い"
-    payment_could_not_be_created: "支払いを作成できませんでした。"
-    payment_information: "支払い情報"
-    payment_method: "支払い方法"
-    payment_methods: "支払い方法"
-    payment_method_not_supported: "その支払い方法はサポートされていません。他のものを選択してください。"
-    payment_processing_failed: "決済が失敗しました。入力した情報を確認してから再び決済を行ってみて下さい。"
-    payment_processor_choose_banner_text: "もし決済処理会社の選択でお困りでしたら、どうぞ"
-    payment_processor_choose_link: "こちらへ"
-    payment_state: "支払い状況"
+    path: パス
+    pay: 支払い
+    payment: 支払い
+    payment_could_not_be_created: 支払いを作成できませんでした。
+    payment_information: 支払い情報
+    payment_method: 支払い方法
+    payment_methods: 支払い方法
+    payment_method_not_supported: その支払い方法はサポートされていません。他のものを選択してください。
+    payment_processing_failed: 決済が失敗しました。入力した情報を確認してから再び決済を行ってみて下さい。
+    payment_processor_choose_banner_text: もし決済処理会社の選択でお困りでしたら、どうぞ
+    payment_processor_choose_link: こちらへ
+    payment_state: 支払い状況
     payment_states:
-      balance_due: "未支払い"
-      checkout: "決算中"
-      completed: "完了"
-      credit_owed: "一部未払"
-      failed: "失敗しました"
-      paid: "支払い済み"
-      pending: "支払い待ち"
-      processing: "処理中"
-      void: "無効"
-    payment_updated: "支払いが更新されました。"
-    payments: "支払い方法"
-    percent: "パーセント"
-    percent_per_item: "アイテムごとのパーセント"
-    permalink: "パーマリンク"
-    pending: "未決定"
-    phone: "電話番号"
-    place_order: "注文を送信する"
-    please_define_payment_methods: "まず支払い方法を定義してください。"
-    please_enter_reasonable_quantity: "適切な量を入力してください。"
-    populate_get_error: "問題が発生しました。もう一度追加してみてください。"
+      balance_due: 未支払い
+      checkout: 決算中
+      completed: 完了
+      credit_owed: 一部未払
+      failed: 失敗しました
+      paid: 支払い済み
+      pending: 支払い待ち
+      processing: 処理中
+      void: 無効
+    payment_updated: 支払いが更新されました。
+    payments: 支払い方法
+    percent: パーセント
+    percent_per_item: アイテムごとのパーセント
+    permalink: パーマリンク
+    pending: 未決定
+    phone: 電話番号
+    place_order: 注文を送信する
+    please_define_payment_methods: まず支払い方法を定義してください。
+    please_enter_reasonable_quantity: 適切な量を入力してください。
+    populate_get_error: 問題が発生しました。もう一度追加してみてください。
     powered_by: Powered by
-    pre_tax_refund_amount: "税前返金料"
-    pre_tax_amount: "税前料金"
-    pre_tax_total: "税前合計"
-    preferred_reimbursement_type: "望ましい返済方法"
-    presentation: "表示名"
-    previous: "前へ"
-    previous_state_missing: "n/a"
-    price: "価格"
-    price_range: "価格帯"
-    price_sack: "プライスサック"
-    process: "処理する"
-    product: "商品"
-    product_details: "商品詳細"
-    product_has_no_description: "この商品に詳細がありません。"
-    product_not_available_in_this_currency: "この商品は選択した通貨では購入できません。"
-    product_properties: "商品情報"
+    pre_tax_refund_amount: 税前返金料
+    pre_tax_amount: 税前料金
+    pre_tax_total: 税前合計
+    preferred_reimbursement_type: 望ましい返済方法
+    presentation: 表示名
+    previous: 前へ
+    previous_state_missing: n/a
+    price: 価格
+    price_range: 価格帯
+    price_sack: プライスサック
+    process: 処理する
+    product: 商品
+    product_details: 商品詳細
+    product_has_no_description: この商品に詳細がありません。
+    product_not_available_in_this_currency: この商品は選択した通貨では購入できません。
+    product_properties: 商品情報
     product_rule:
-      choose_products: "商品を選択してください"
+      choose_products: 商品を選択してください
       label:
-      match_all: "少なくとも一つ"
-      match_any: "すべて"
-      match_none: "なし"
+      match_all: 少なくとも一つ
+      match_any: すべて
+      match_none: なし
       product_source:
-        group: "商品グループから"
-        manual: "手動で選択"
-    products: "商品"
-    listing_products: "商品一覧"
-    promotion: "プロモーション"
-    promotionable: "プロモーション可能"
-    promotion_action: "プロモーションアクション"
+        group: 商品グループから
+        manual: 手動で選択
+    products: 商品
+    promotion: プロモーション
+    promotionable: プロモーション可能
+    promotion_action: プロモーションアクション
     promotion_action_types:
       create_adjustment:
-        description: "注文に対して値引きする"
-        name: "値引き"
+        description: 注文に対して値引きする
+        name: 値引き
       create_item_adjustments:
-        description: "品目にプロモーションクレジット値引きを作成"
-        name: "品目ごとの値引きを作成"
+        description: 品目にプロモーションクレジット値引きを作成
+        name: 品目ごとの値引きを作成
       create_line_items:
-        description: "特定の種類の商品をカートに加える"
-        name: "商品追加"
+        description: 特定の種類の商品をカートに加える
+        name: 商品追加
       free_shipping:
-        description: "すべての発送を無料にする"
-        name: "発送無料"
-    promotion_actions: "アクション"
-    promotion_category: "プロモーションカテゴリ"
+        description: すべての発送を無料にする
+        name: 発送無料
+    promotion_actions: アクション
+    promotion_category: プロモーションカテゴリ
     promotion_form:
       match_policies:
-        all: "以下のルールすべてに該当する"
-        any: "以下のルールのいずれかに該当する"
-    promotion_rule: "プロモーションルール"
+        all: 以下のルールすべてに該当する
+        any: 以下のルールのいずれかに該当する
+    promotion_rule: プロモーションルール
     promotion_rule_types:
       first_order:
-        description: "最初の注文である"
-        name: "最初の注文"
+        description: 最初の注文である
+        name: 最初の注文
       item_total:
-        description: "合計個数"
-        name: "合計個数"
+        description: 合計個数
+        name: 合計個数
       landing_page:
-        description: "お客様が特定のページを訪問済みである"
-        name: "ランディングページ"
+        description: お客様が特定のページを訪問済みである
+        name: ランディングページ
       one_use_per_user:
-        description: "ユーザーごとに一つ"
-        name: "ユーザーごとに一つ"
+        description: ユーザーごとに一つ
+        name: ユーザーごとに一つ
       option_value:
-        description: "マッチするオプション値を含んだ注文"
-        name: "オプション値"
+        description: マッチするオプション値を含んだ注文
+        name: オプション値
       product:
-        description: "注文に特定の商品を含む"
-        name: "商品"
+        description: 注文に特定の商品を含む
+        name: 商品
       user:
-        description: "特定のユーザー限定"
-        name: "ユーザー"
+        description: 特定のユーザー限定
+        name: ユーザー
       user_logged_in:
-        description: "ログイン中のユーザー限定"
-        name: "ログイン中のユーザー"
+        description: ログイン中のユーザー限定
+        name: ログイン中のユーザー
       taxon:
-        description: "指定したジャンル単位のみ"
-        name: "ジャンル単位"
-    promotions: "プロモーション"
-    promotion_uses: "プロモーション"
+        description: 指定したジャンル単位のみ
+        name: ジャンル単位
+    promotions: プロモーション
+    promotion_uses: プロモーション
     propagate_all_variants:
-    properties: "属性"
-    property: "属性"
-    prototype: "原型"
-    prototypes: "原型"
-    provider: "プロバイダー"
-    provider_settings_warning: "プロバイダータイプを変更する時は、プロバイダー設定を編集する前に保存しなければなりません。"
-    qty: "個数"
-    quantity: "量"
-    quantity_returned: "返送された数"
-    quantity_shipped: "発送された数"
-    quick_search: "クイック検索"
-    rate: "比率"
-    reason: "理由"
-    receive: "受信"
+    properties: 属性
+    property: 属性
+    prototype: 原型
+    prototypes: 原型
+    provider: プロバイダー
+    provider_settings_warning: プロバイダータイプを変更する時は、プロバイダー設定を編集する前に保存しなければなりません。
+    qty: 個数
+    quantity: 量
+    quantity_returned: 返送された数
+    quantity_shipped: 発送された数
+    quick_search: クイック検索
+    rate: 比率
+    reason: 理由
+    receive: 受信
     receive_stock:
-    received: "受信した"
-    reception_status: "受信したステータス"
-    reference: "参照"
-    reference_contains: "参照含む"
-    refund: "払い戻し"
-    refund_amount_must_be_greater_than_zero: "0以上の返金料"
-    refund_reasons: "返金理由"
-    refunded_amount: "返金料"
-    refunds: "返金"
-    register: "新規ユーザーとして登録"
-    registration: "登録"
-    reimburse: "払い戻す"
-    reimbursed: "払い戻し済み"
-    reimbursement: "払い戻し"
-    reimbursement_perform_failed: "払い戻しが実行できませんでした。 %{error}"
-    reimbursement_status: "払い戻しステータス"
-    reimbursement_type: "払い戻しタイプ"
-    reimbursement_type_override: "払い戻しタイプ上書き"
-    reimbursement_types: "払い戻しタイプ"
-    reimbursements: "払い戻し"
-    reject: "拒否"
-    rejected: "拒否済み"
-    remember_me: "記録する"
-    remove: "削除"
-    rename: "リネーム"
-    report: "レポート"
-    reports: "レポート"
-    resellable: "再販売可能"
-    resend: "再送信"
-    reset_password: "パスワードを再設定する"
-    response_code: "レスポンスコード"
-    resume: "再開"
-    resumed: "再開された"
-    return: "返品"
-    return_authorization: "返品承認"
-    return_authorization_reasons: "返品承認理由"
-    return_authorization_updated: "返品承認が更新されました"
-    return_authorizations: "返品承認"
-    return_item_inventory_unit_ineligible: "返品の在庫ユニットは発送済みでなければなりません。"
-    return_item_inventory_unit_reimbursed: "返品在庫ユニットは既に払い戻し済みです。"
-    return_item_order_not_completed: "返品注文は完了されていなければなりません。"
-    return_item_rma_ineligible: "返品にはRMAが必要です。"
-    return_item_time_period_ineligible: "返品は期限切れです。"
-    return_items: "返品"
-    return_items_cannot_be_associated_with_multiple_orders: "返品商品は複数の注文の注文と関連づけることはできません。"
-    reimbursement_mailer: 
+    received: 受信した
+    reception_status: 受信したステータス
+    reference: 参照
+    reference_contains: 参照含む
+    refund: 払い戻し
+    refund_amount_must_be_greater_than_zero: 0以上の返金料
+    refund_reasons: 返金理由
+    refunded_amount: 返金料
+    refunds: 返金
+    register: 新規ユーザーとして登録
+    registration: 登録
+    reimburse: 払い戻す
+    reimbursed: 払い戻し済み
+    reimbursement: 払い戻し
+    reimbursement_perform_failed: 払い戻しが実行できませんでした。 %{error}
+    reimbursement_status: 払い戻しステータス
+    reimbursement_type: 払い戻しタイプ
+    reimbursement_type_override: 払い戻しタイプ上書き
+    reimbursement_types: 払い戻しタイプ
+    reimbursements: 払い戻し
+    reject: 拒否
+    rejected: 拒否済み
+    remember_me: 記録する
+    remove: 削除
+    rename: リネーム
+    report: レポート
+    reports: レポート
+    resellable: 再販売可能
+    resend: 再送信
+    reset_password: パスワードを再設定する
+    response_code: レスポンスコード
+    resume: 再開
+    resumed: 再開された
+    return: 返品
+    return_authorization: 返品承認
+    return_authorization_reasons: 返品承認理由
+    return_authorization_updated: 返品承認が更新されました
+    return_authorizations: 返品承認
+    return_item_inventory_unit_ineligible: 返品の在庫ユニットは発送済みでなければなりません。
+    return_item_inventory_unit_reimbursed: 返品在庫ユニットは既に払い戻し済みです。
+    return_item_order_not_completed: 返品注文は完了されていなければなりません。
+    return_item_rma_ineligible: 返品にはRMAが必要です。
+    return_item_time_period_ineligible: 返品は期限切れです。
+    return_items: 返品
+    return_items_cannot_be_associated_with_multiple_orders: 返品商品は複数の注文の注文と関連づけることはできません。
+    reimbursement_mailer:
       reimbursement_email:
-        days_to_send: "交換待ちの商品を送り返すのに%{days}必要です。"
-        dear_customer: "お客様"
-        exchange_summary: "交換概要"
-        for: "for"
-        instructions: "返品が実行されました。"
-        refund_summary: "返品概要"
-        subject: "返品通知"
-        total_refunded: "返金合計: %{total}"
-    return_number: "返品番号"
-    return_quantity: "返品数"
-    returned: "返品済み"
-    returns: "返品"
-    review: "内容を確認する"
-    risk: "リスク"
-    risk_analysis: "リスク解析"
-    risky: "リスクのある"
+        days_to_send: 交換待ちの商品を送り返すのに%{days}必要です。
+        dear_customer: お客様
+        exchange_summary: 交換概要
+        for: for
+        instructions: 返品が実行されました。
+        refund_summary: 返品概要
+        subject: 返品通知
+        total_refunded: '返金合計: %{total}'
+    return_number: 返品番号
+    return_quantity: 返品数
+    returned: 返品済み
+    returns: 返品
+    review: 内容を確認する
+    risk: リスク
+    risk_analysis: リスク解析
+    risky: リスクのある
     rma_credit: RMAクレジット
     rma_number: RMA番号
     rma_value: RMA値
-    role_id: "役割ID"
-    roles: "役割"
-    rules: "ルール"
-    safe: "安全"
-    sales_total: "売上げ合計"
-    sales_total_description: "全注文の売上合計"
-    sales_totals: "売上合計"
-    save_and_continue: "保存して続行"
-    save_my_address: "住所の保存"
-    say_no: "いいえ"
-    say_yes: "はい"
-    scope: "範囲"
-    search: "検索"
+    role_id: 役割ID
+    roles: 役割
+    rules: ルール
+    safe: 安全
+    sales_total: 売上げ合計
+    sales_total_description: 全注文の売上合計
+    sales_totals: 売上合計
+    save_and_continue: 保存して続行
+    save_my_address: 住所の保存
+    say_no: いいえ
+    say_yes: はい
+    scope: 範囲
+    search: 検索
     search_results: "'%{keywords}' の検索結果"
-    searching: "検索中"
-    secure_connection_type: "接続保護のタイプ"
-    security_settings: "セキュリティの設定"
-    select: "選択"
-    select_from_prototype: "原型から選択"
-    select_a_return_authorization_reason: "返品認証の理由を選択してください"
-    select_a_stock_location: "在庫場所の選択"
-    select_stock: "在庫の選択"
-    selected_quantity_not_available: ! '%{item}の選択は利用不可です。'
-    send_copy_of_all_mails_to: "全てのメールのコピーをこの宛先に送る"
-    send_mails_as: "メール送信者名"
-    server: "サーバ"
-    server_error: "サーバーエラー"
-    settings: "設定"
-    ship: "配送"
-    ship_address: "配送先住所"
-    ship_total: "発送合計"
-    shipment: "発送"
-    shipment_adjustments: "発送値引き"
-    shipment_details: "発送詳細"
+    searching: 検索中
+    secure_connection_type: 接続保護のタイプ
+    security_settings: セキュリティの設定
+    select: 選択
+    select_from_prototype: 原型から選択
+    select_a_return_authorization_reason: 返品認証の理由を選択してください
+    select_a_stock_location: 在庫場所の選択
+    select_stock: 在庫の選択
+    selected_quantity_not_available: "%{item}の選択は利用不可です。"
+    send_copy_of_all_mails_to: 全てのメールのコピーをこの宛先に送る
+    send_mails_as: メール送信者名
+    server: サーバ
+    server_error: サーバーエラー
+    settings: 設定
+    ship: 配送
+    ship_address: 配送先住所
+    ship_total: 発送合計
+    shipment: 発送
+    shipment_adjustments: 発送値引き
+    shipment_details: 発送詳細
     shipment_mailer:
       shipped_email:
-        dear_customer: "お客様"
-        instructions: "注文した商品を発送しました。"
-        shipment_summary: "発送概要"
-        subject: "発送の通知"
-        thanks: "ご利用ありがとうございました。"
-        track_information: "トラック情報 %{tracking}"
+        dear_customer: お客様
+        instructions: 注文した商品を発送しました。
+        shipment_summary: 発送概要
+        subject: 発送の通知
+        thanks: ご利用ありがとうございました。
+        track_information: トラック情報 %{tracking}
         track_link: 'トラックURL: %{url}'
-    shipment_state: "配送状況"
+    shipment_state: 配送状況
     shipment_states:
-      backorder: "入荷待ち"
-      canceled: "キャンセル済み"
-      partial: "一部配送"
-      pending: "配送準備中"
-      ready: "配送可能"
-      shipped: "配送済み"
-    shipment_transfer_success: "種別の移動に成功しました。"
-    shipment_transfer_error: "種別の移動中にエラーが発生しました。"
-    shipments: "配送"
-    shipped: "発送済"
-    shipping: "送料"
-    shipping_address: "配送先"
-    shipping_categories: "配送カテゴリー"
-    shipping_category: "配送カテゴリー"
-    shipping_flat_rate_per_item: "パッケージ商品ごとに均一の比率"
-    shipping_flat_rate_per_order: "均一の比率"
-    shipping_flexible_rate: "パッケージ商品ごとに柔軟な比率"
-    shipping_instructions: "配送に関して"
-    shipping_method: "配送方法"
-    shipping_methods: "配送方法"
-    shipping_price_sack: "袋値段"
-    shipping_total: "配送合計"
+      backorder: 入荷待ち
+      canceled: キャンセル済み
+      partial: 一部配送
+      pending: 配送準備中
+      ready: 配送可能
+      shipped: 配送済み
+    shipment_transfer_success: 種別の移動に成功しました。
+    shipment_transfer_error: 種別の移動中にエラーが発生しました。
+    shipments: 配送
+    shipped: 発送済
+    shipping: 送料
+    shipping_address: 配送先
+    shipping_categories: 配送カテゴリー
+    shipping_category: 配送カテゴリー
+    shipping_flat_rate_per_item: パッケージ商品ごとに均一の比率
+    shipping_flat_rate_per_order: 均一の比率
+    shipping_flexible_rate: パッケージ商品ごとに柔軟な比率
+    shipping_instructions: 配送に関して
+    shipping_method: 配送方法
+    shipping_methods: 配送方法
+    shipping_price_sack: 袋値段
+    shipping_total: 配送合計
     shop_by_taxonomy: "%{taxonomy}"
-    shopping_cart: "ショッピングカート"
-    show: "表示"
-    show_active: "有効のを表示する"
-    show_deleted: "削除済みのを表示"
-    show_only_complete_orders: "処理済みの注文のみを表示"
-    show_only_considered_risky: "リスクのあるオーダーのみ表示"
-    show_rate_in_label: "税率を見る"
-    sku: "品番[SKU]"
-    skus: "品番[SKU]"
-    slug: "スラグ"
-    source: "ソース"
-    special_instructions: "特別な指示"
-    split: "分割"
-    spree_gateway_error_flash_for_checkout: "支払い情報に問題があります。情報をお確かめになり再試行願います。"
+    shopping_cart: ショッピングカート
+    show: 表示
+    show_active: 有効のを表示する
+    show_deleted: 削除済みのを表示
+    show_only_complete_orders: 処理済みの注文のみを表示
+    show_only_considered_risky: リスクのあるオーダーのみ表示
+    show_rate_in_label: 税率を見る
+    sku: 品番[SKU]
+    skus: 品番[SKU]
+    slug: スラグ
+    source: ソース
+    special_instructions: 特別な指示
+    split: 分割
+    spree_gateway_error_flash_for_checkout: 支払い情報に問題があります。情報をお確かめになり再試行願います。
     ssl:
-      change_protocol: "HTTPSではなくHTTPプロトコルに切り替えて再度リクエストしてください。"
-    start: "始め"
-    state: "都道府県（州）"
-    state_based: "都道府県（州）による区別"
-    states: "都道府県（州）"
+      change_protocol: HTTPSではなくHTTPプロトコルに切り替えて再度リクエストしてください。
+    start: 始め
+    state: 都道府県（州）
+    state_based: 都道府県（州）による区別
+    states: 都道府県（州）
     state_machine_states:
-      accepted: "受付"
-      address: "住所"
-      authorized: "認可済み"
-      awaiting: "待ち"
-      awaiting_return: "返品待ち"
-      backordered: "オーダー済み"
-      canceled: "キャンセル済み"
-      cart: "カート"
-      checkout: "チェックアウト"
-      closed: "閉鎖"
-      complete: "完了"
-      completed: "完了済み"
-      confirm: "確認"
-      delivery: "配送"
-      errored: "エラー"
-      failed: "失敗"
-      given_to_customer: "ふさわしい顧客"
-      invalid: "不正"
-      manual_intervention_required: "手動介入が必要"
-      open: "公開"
-      order: "注文"
-      on_hand: "主導"
-      payment: "支払い"
-      pending: "停止"
-      processing: "処理中"
-      ready: "準備完了"
-      reimbursed: "返品済み"
-      resumed: "再開"
-      returned: "返品"
-      shipped: "配送済み"
-      void: "空"
-    states_required: "必須"
-    status: "状況"
-    stock: "在庫"
-    stock_location: "在庫位置"
-    stock_location_info: "在庫位置情報"
-    stock_locations: "在庫位置"
-    stock_locations_need_a_default_country: "在庫位置を作成する前にデフォルトの国を作る必要があります。"
-    stock_management: "在庫管理"
-    stock_management_requires_a_stock_location: "在庫を管理するために在庫位置を作成してください。"
-    stock_movements: "在庫移動"
+      accepted: 受付
+      address: 住所
+      authorized: 認可済み
+      awaiting: 待ち
+      awaiting_return: 返品待ち
+      backordered: オーダー済み
+      canceled: キャンセル済み
+      cart: カート
+      checkout: チェックアウト
+      closed: 閉鎖
+      complete: 完了
+      completed: 完了済み
+      confirm: 確認
+      delivery: 配送
+      errored: エラー
+      failed: 失敗
+      given_to_customer: ふさわしい顧客
+      invalid: 不正
+      manual_intervention_required: 手動介入が必要
+      open: 公開
+      order: 注文
+      on_hand: 主導
+      payment: 支払い
+      pending: 停止
+      processing: 処理中
+      ready: 準備完了
+      reimbursed: 返品済み
+      resumed: 再開
+      returned: 返品
+      shipped: 配送済み
+      void: 空
+    states_required: 必須
+    status: 状況
+    stock: 在庫
+    stock_location: 在庫位置
+    stock_location_info: 在庫位置情報
+    stock_locations: 在庫位置
+    stock_locations_need_a_default_country: 在庫位置を作成する前にデフォルトの国を作る必要があります。
+    stock_management: 在庫管理
+    stock_management_requires_a_stock_location: 在庫を管理するために在庫位置を作成してください。
+    stock_movements: 在庫移動
     stock_movements_for_stock_location: "%{stock_location_name}への在庫移動"
     stock_successfully_transferred: 在庫の在庫地館での移動が完了しました。""
-    stock_transfer: "在庫移動"
-    stock_transfers: "在庫移動"
-    stop: "終わり"
-    store: "ストア"
-    street_address: "住所"
-    street_address_2: "住所の続き"
-    subtotal: "合計"
-    subtract: "引く"
-    success: "成功"
+    stock_transfer: 在庫移動
+    stock_transfers: 在庫移動
+    stop: 終わり
+    store: ストア
+    street_address: 住所
+    street_address_2: 住所の続き
+    subtotal: 合計
+    subtract: 引く
+    success: 成功
     successfully_created: "%{resource}が作成されました!"
     successfully_refunded: "%{resource}は返金されました！"
     successfully_removed: "%{resource}が削除されました!"
-    successfully_signed_up_for_analytics: "Spree解析のログインに成功しました"
+    successfully_signed_up_for_analytics: Spree解析のログインに成功しました
     successfully_updated: "%{resource}が更新されました!"
-    summary: "概要"
-    tax: "税金"
-    tax_included: "税金 (incl.)"
-    tax_categories: "税金カテゴリー"
-    tax_category: "税金カテゴリー"
-    tax_code: "税金コード"
-    tax_rate_amount_explanation: "税率は5%のとき、0.05と入力します。"
-    tax_rates: "税率"
-    taxon: "ジャンル単位"
-    taxon_edit: "ジャンル単位を編集"
-    taxon_placeholder: "ジャンル単位プレイスホルダ"
+    summary: 概要
+    tax: 税金
+    tax_included: 税金 (incl.)
+    tax_categories: 税金カテゴリー
+    tax_category: 税金カテゴリー
+    tax_code: 税金コード
+    tax_rate_amount_explanation: 税率は5%のとき、0.05と入力します。
+    tax_rates: 税率
+    taxon: ジャンル単位
+    taxon_edit: ジャンル単位を編集
+    taxon_placeholder: ジャンル単位プレイスホルダ
     taxon_rule:
-      choose_taxons: "ジャンル単位の選択"
-      label: "注文はこれらの分類単位を含まなければなりません。"
-      match_all: "すべて"
-      match_any: "最低一つ"
-    taxonomies: "ジャンルツリー"
-    taxonomy: "ジャンルツリー"
-    taxonomy_edit: "ジャンルツリーを編集する"
-    taxonomy_tree_error: "要求された変更は受け付けられず、ツリーは以前の状態に戻っています。再度お試しください。"
+      choose_taxons: ジャンル単位の選択
+      label: 注文はこれらの分類単位を含まなければなりません。
+      match_all: すべて
+      match_any: 最低一つ
+    taxonomies: ジャンルツリー
+    taxonomy: ジャンルツリー
+    taxonomy_edit: ジャンルツリーを編集する
+    taxonomy_tree_error: 要求された変更は受け付けられず、ツリーは以前の状態に戻っています。再度お試しください。
     taxonomy_tree_instruction: "* 追加・削除・ソートなどのメニューを選択するには、ツリーのノードを右クリックしてください。"
-    taxons: "ジャンル単位"
-    test: "テスト"
+    taxons: ジャンル単位
+    test: テスト
     test_mailer:
       test_email:
-        greeting: "おめでとうございます！"
-        message: "もしこのメールを受け取ったのなら、あなたのメール設定は正しいです。"
-        subject: "テストメール"
-    test_mode: "テストモード"
-    thank_you_for_your_order: "ご注文ありがとうございます。この確認画面を控えとして印刷してください。"
-    there_are_no_items_for_this_order: "この注文に商品が一つもありません。続けるには商品を追加してください。"
-    there_were_problems_with_the_following_fields: "以下の入力欄で問題がありました"
-    this_order_has_already_received_a_refund: "この注文は既に返金受け取り済みです。"
-    thumbnail: "サムネイル"
-    tiers: "列"
-    tiered_flat_rate: "列の均一料金"
-    tiered_percent: "列パーセント"
-    time: "時間"
-    to_add_variants_you_must_first_define: "種類を追加するには、まず以下を定義する必要があります。"
-    total: "合計"
-    total_per_item: "商品ごとの合計"
-    total_pre_tax_refund: "税引き前の返金合計"
-    total_price: "合計金額"
-    total_sales: "合計売上"
-    track_inventory: "在庫を追跡"
-    tracking: "追跡"
-    tracking_number: "追跡ナンバー"
-    tracking_url: "追跡URL"
-    tracking_url_placeholder: "e.g.http://quickship.com/package?num=:tracking"
-    transaction_id: "取引ID"
-    transfer_from_location: "移動(From)"
-    transfer_stock: "在庫の移動"
-    transfer_to_location: "移動(To)"
-    tree: "ツリー"
-    type: "支払い方法"
-    type_to_search: "何か入力すると検索します"
-    unable_to_connect_to_gateway: "ゲートウェイに接続できません。"
-    unable_to_create_reimbursements: "手動介入で停止中の商品があるため、返品の作成ができませんでした。"
+        greeting: おめでとうございます！
+        message: もしこのメールを受け取ったのなら、あなたのメール設定は正しいです。
+        subject: テストメール
+    test_mode: テストモード
+    thank_you_for_your_order: ご注文ありがとうございます。この確認画面を控えとして印刷してください。
+    there_are_no_items_for_this_order: この注文に商品が一つもありません。続けるには商品を追加してください。
+    there_were_problems_with_the_following_fields: 以下の入力欄で問題がありました
+    this_order_has_already_received_a_refund: この注文は既に返金受け取り済みです。
+    thumbnail: サムネイル
+    tiers: 列
+    tiered_flat_rate: 列の均一料金
+    tiered_percent: 列パーセント
+    time: 時間
+    to_add_variants_you_must_first_define: 種類を追加するには、まず以下を定義する必要があります。
+    total: 合計
+    total_per_item: 商品ごとの合計
+    total_pre_tax_refund: 税引き前の返金合計
+    total_price: 合計金額
+    total_sales: 合計売上
+    track_inventory: 在庫を追跡
+    tracking: 追跡
+    tracking_number: 追跡ナンバー
+    tracking_url: 追跡URL
+    tracking_url_placeholder: e.g.http://quickship.com/package?num=:tracking
+    transaction_id: 取引ID
+    transfer_from_location: 移動(From)
+    transfer_stock: 在庫の移動
+    transfer_to_location: 移動(To)
+    tree: ツリー
+    type: 支払い方法
+    type_to_search: 何か入力すると検索します
+    unable_to_connect_to_gateway: ゲートウェイに接続できません。
+    unable_to_create_reimbursements: 手動介入で停止中の商品があるため、返品の作成ができませんでした。
     under_price: "%{price}より安い"
-    unlock: "ロック解除"
-    unrecognized_card_type: "認識できないカードタイプ"
-    unshippable_items: "配送不可の商品"
-    update: "更新"
-    updating: "更新中"
-    usage_limit: "使用制限"
-    use_app_default: "App デフォルトを利用する"
-    use_billing_address: "請求先住所を使用する"
-    use_existing_cc: "保存済みカード情報を利用する"
-    use_new_cc: "新しいカードを使用する"
-    use_new_cc_or_payment_method: "新しいカードを利用 / 支払い方法"
-    use_s3: "商品画像の保存にAmazon S3を使用する"
-    user: "ユーザー"
+    unlock: ロック解除
+    unrecognized_card_type: 認識できないカードタイプ
+    unshippable_items: 配送不可の商品
+    update: 更新
+    updating: 更新中
+    usage_limit: 使用制限
+    use_app_default: App デフォルトを利用する
+    use_billing_address: 請求先住所を使用する
+    use_existing_cc: 保存済みカード情報を利用する
+    use_new_cc: 新しいカードを使用する
+    use_new_cc_or_payment_method: 新しいカードを利用 / 支払い方法
+    use_s3: 商品画像の保存にAmazon S3を使用する
+    user: ユーザー
     user_rule:
-      choose_users: "ユーザーの選択"
-    users: "ユーザー"
+      choose_users: ユーザーの選択
+    users: ユーザー
     validation:
-      unpaid_amount_not_zero: "量を完全に返品できません。 Still due: %{amount}"
-      cannot_be_less_than_shipped_units: "配送ユニットの個数より小さくはできません"
-      cannot_destroy_line_item_as_inventory_units_have_shipped: "いくつかの在庫が発送されたため項目を削除できません。"
-      exceeds_available_stock: "可能な在庫数を上回っています。項目の個数が正しく入力されていることを確認してください。"
-      is_too_large: "要求された量は在庫を超えています。"
-      must_be_int: "整数であることが必要です"
-      must_be_non_negative: "0以上の数字が必要です"
-    value: "値"
-    variant: "種類"
-    variant_search_placeholder: "品名もしくは品番[SKU]"
-    variant_placeholder: "種類プレイスホルダ"
-    variants: "種類"
-    version: "バージョン"
-    void: "無効"
-    weight: "重量"
-    what_is_a_cvv: "カード照合値(CVV)とは?"
-    what_is_this: "これは何?"
-    width: "横幅"
-    year: "年"
-    you_have_no_orders_yet: "まだ注文がありません。"
-    your_cart_is_empty: "カートは空です"
-    your_order_is_empty_add_product: "注文が空です。検索し商品を追加してください。"
-    zip: "郵便番号"
-    zipcode: "郵便番号コード"
-    zone: "ゾーン"
-    zones: "ゾーン"
+      unpaid_amount_not_zero: '量を完全に返品できません。 Still due: %{amount}'
+      cannot_be_less_than_shipped_units: 配送ユニットの個数より小さくはできません
+      cannot_destroy_line_item_as_inventory_units_have_shipped: いくつかの在庫が発送されたため項目を削除できません。
+      exceeds_available_stock: 可能な在庫数を上回っています。項目の個数が正しく入力されていることを確認してください。
+      is_too_large: 要求された量は在庫を超えています。
+      must_be_int: 整数であることが必要です
+      must_be_non_negative: 0以上の数字が必要です
+    value: 値
+    variant: 種類
+    variant_search_placeholder: 品名もしくは品番[SKU]
+    variant_placeholder: 種類プレイスホルダ
+    variants: 種類
+    version: バージョン
+    void: 無効
+    weight: 重量
+    what_is_a_cvv: カード照合値(CVV)とは?
+    what_is_this: これは何?
+    width: 横幅
+    year: 年
+    you_have_no_orders_yet: まだ注文がありません。
+    your_cart_is_empty: カートは空です
+    your_order_is_empty_add_product: 注文が空です。検索し商品を追加してください。
+    zip: 郵便番号
+    zipcode: 郵便番号コード
+    zone: ゾーン
+    zones: ゾーン

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,57 +1,110 @@
 ja:
+  activemodel:
+    attributes:
+      spree/order_cancellations:
+        cancel: キャンセル
+        quantity: 量
+        shipment: 発送
+        state: 都道府県（州）
   activerecord:
     attributes:
       spree/address:
         address1: 住所1
         address2: 住所2
         city: 市区町村
+        company: 会社
         country: 国
         firstname: 名前（名）
         lastname: 名前（姓）
         phone: 電話番号
         state: 都道府県（州）
         zipcode: 郵便番号
+      spree/adjustment:
+        adjustable: 調整可能
+        adjustment_reason_id: 理由
+        amount: 金額
+        label: 説明
+        name: 名称
+        state: 都道府県（州）
+      spree/adjustment_reason:
+        active: 有効
+        code: コード
+        name: 名称
+        state: 都道府県（州）
+      spree/calculator/flat_rate:
+        preferred_amount: 金額
       spree/calculator/tiered_flat_rate:
         preferred_base_amount: 基準量
         preferred_tiers: 列
       spree/calculator/tiered_percent:
         preferred_base_percent: 基本％
         preferred_tiers: 列
+      spree/carton:
+        tracking: 追跡
       spree/country:
         iso: ISO
         iso3: ISO3
         iso_name: ISO名
         name: 名
         numcode: ISOコード
+        states_required: 必須
       spree/credit_card:
         base:
+        card_code: カード照合値[セキュリティーコード]
         cc_type: カード類
+        expiration: 有効期限
         month: 月
         name: 名前
         number: カード番号
         verification_value: 照合コード
         year: 年
+      spree/customer_return:
+        name: 名称
+        number: 返品番号
+        pre_tax_total: 税前合計
+        reimbursement_status: 払い戻しステータス
+        total: 合計
+      spree/image:
+        alt: 代替のテキスト
+        attachment: ファイル名
       spree/inventory_unit:
         state: 都道府県（州）
+      spree/legacy_user:
+        email: Eメール
+        password: パスワード
+        password_confirmation: パスワードの確認
       spree/line_item:
+        description: アイテム説明
+        name: 名称
         price: 価格
         quantity: 数量
+        total: 合計金額
       spree/option_type:
         name: 名称
         presentation: 表示
+      spree/option_value:
+        name: 名称
+        presentation: 表示名
       spree/order:
+        additional_tax_total: 税金
+        approved_at: 承認日時
+        approver_id: 承認者
+        canceled_at: にキャンセル
+        canceler_id: キャンセル者
         checkout_complete: 注文の受け付けを完了しました
         completed_at: 完了日時
         considered_risky: リスク度
         coupon_code: クーポンコード
         created_at: 注文日
         email: メールアドレス
+        included_tax_total: 税金 (incl.)
         ip_address: IPアドレス
         item_total: 合計個数
         name: 注文
         number: 注文番号
         payment_state: 支払い状態
         shipment_state: 配送状態
+        shipment_total: 発送合計
         special_instructions: 特記事項
         state: 状態
         total: 合計
@@ -74,18 +127,40 @@ ja:
       spree/payment:
         amount: 金額
         number: 数量
+        response_code: 取引ID
+        state: 支払い状況
       spree/payment_method:
+        active: 有効
+        auto_capture: 自動キャプチャ
+        description: 説明
+        display_on: 表示
         name: 名称
+        type: プロバイダー
+      spree/price:
+        amount: 価格
+        currency: 通貨
       spree/product:
         available_on: 販売開始日
         cost_currency: コストカレンシー
         cost_price: 原価
+        depth: 奥行き
         description: 説明
+        height: 高さ
         master_price: 値段
+        meta_description: メタ情報説明
+        meta_keywords: メタキーワード
+        meta_title: メタタイトル
         name: 商品名
         on_hand: 入荷数
+        price: 定価
+        promotionable: プロモーション可能
         shipping_category: 配達区間
+        slug: スラグ
         tax_category: 税区
+        weight: 重量
+        width: 横幅
+      spree/product_property:
+        value: 値
       spree/promotion:
         advertise: 表示する
         code: コード
@@ -103,12 +178,59 @@ ja:
         presentation: 表示
       spree/prototype:
         name: 名称
+      spree/refund:
+        amount: 金額
+        description: 説明
+        refund_reason_id: 理由
+      spree/refund_reason:
+        active: 有効
+        code: コード
+        name: 名称
+      spree/reimbursement:
+        number: 注文番号
+        reimbursement_status: 状況
+        total: 合計
+      spree/reimbursement/credit:
+        amount: 金額
+      spree/reimbursement_type:
+        name: 名称
+        type: 支払い方法
       spree/return_authorization:
         amount: 合計
+        pre_tax_total: 税前合計
+      spree/return_item:
+        acceptance_status: 受諾ステータス
+        acceptance_status_errors: 受諾エラー
+        charged: 支払い済み
+        exchange_variant: に変換
+        inventory_unit_state: 都道府県（州）
+        override_reimbursement_type_id: 払い戻しタイプ上書き
+        preferred_reimbursement_type_id: 望ましい返済方法
+        reception_status: 受信したステータス
+        return_reason: 理由
+        total: 合計
+      spree/return_reason:
+        active: 有効
+        memo: メモ
+        name: 名称
+        number: RMA番号
+        state: 都道府県（州）
       spree/role:
         name: 名称
       spree/shipment:
         number: 数量
+        tracking: 追跡ナンバー
+      spree/shipping_category:
+        name: 名称
+      spree/shipping_method:
+        admin_name: 内部の名前
+        code: コード
+        display_on: 表示
+        name: 名称
+        tracking_url: 追跡URL
+      spree/shipping_rate:
+        amount: 金額
+        tax_rate: 税率
       spree/state:
         abbr: 略語
         name: 名称
@@ -120,6 +242,31 @@ ja:
         type: タイプ
         updated: 更新
         user: ユーザー
+      spree/stock_item:
+        count_on_hand: 手計算
+      spree/stock_location:
+        active: 有効
+        address1: 住所
+        address2: 住所の続き
+        admin_name: 内部の名前
+        backorderable_default: 入荷待ちデフォルト
+        city: 市区町村
+        code: コード
+        country_id: 国
+        default: 初期設定
+        internal_name: 内部の名前
+        name: 名称
+        phone: 電話番号
+        propagate_all_variants:
+        state_id: 都道府県（州）
+        zipcode: 郵便番号
+      spree/stock_movement:
+        action: アクション
+        quantity: 量
+      spree/stock_transfer:
+        created_at: 作成日時
+        description: 説明
+        tracking_number: 追跡ナンバー
       spree/store:
         mail_from_address: メールアドレス
         meta_description: メタ 説明
@@ -127,19 +274,35 @@ ja:
         name: サイト名
         seo_title: SEO タイトル
         url: サイトURL
+      spree/store_credit:
+        amount: 金額
+        memo: メモ
+      spree/store_credit_event:
+        action: アクション
       spree/tax_category:
         description: 説明
+        is_default: 初期設定
         name: 名称
+        tax_code: 税金コード
       spree/tax_rate:
         amount: 率
         included_in_price: 税込み
+        name: 名称
         show_rate_in_label: 税率を見る
       spree/taxon:
+        description: 説明
+        icon: アイコン
+        meta_description: メタ情報説明
+        meta_keywords: メタキーワード
+        meta_title: メタタイトル
         name: 名称
         permalink: 固定リンク
         position: 位置
       spree/taxonomy:
         name: 名称
+      spree/tracker:
+        active: 有効
+        analytics_id: Google アナリティクス ID
       spree/user:
         email: Eメール
         password: パスワード
@@ -154,6 +317,7 @@ ja:
         weight: 重量
         width: 幅
       spree/zone:
+        default_tax: デフォルトのタックスゾーン
         description: 説明
         name: 名前
     errors:
@@ -221,6 +385,57 @@ ja:
       spree/address:
         one: 住所
         other: 住所
+      spree/adjustment:
+        one: 調整（値引き・追加料金）
+        other: 調整（値引き・追加料金）
+      spree/calculator/default_tax:
+        one: デフォルトの税
+        other: デフォルトの税
+      spree/calculator/flat_percent_item_total:
+        one: 定率
+        other: 定率
+      spree/calculator/flat_rate:
+        one: 定格(一注文につき)
+        other: 定格(一注文につき)
+      spree/calculator/flexi_rate:
+        one: 変動料金
+        other: 変動料金
+      spree/calculator/free_shipping:
+        one: 配送料無料
+        other: 配送料無料
+      spree/calculator/percent_on_line_item:
+        one: アイテムごとのパーセント
+        other: アイテムごとのパーセント
+      spree/calculator/percent_per_item:
+        one: アイテムごとのパーセント
+        other: アイテムごとのパーセント
+      spree/calculator/price_sack:
+        one: プライスサック
+        other: プライスサック
+      spree/calculator/returns/default_refund_amount:
+        one:
+        other:
+      spree/calculator/shipping/flat_percent_item_total:
+        one: 定率
+        other: 定率
+      spree/calculator/shipping/flat_rate:
+        one: 均一の比率
+        other: 均一の比率
+      spree/calculator/shipping/flexi_rate:
+        one: パッケージ商品ごとに柔軟な比率
+        other: パッケージ商品ごとに柔軟な比率
+      spree/calculator/shipping/per_item:
+        one: パッケージ商品ごとに均一の比率
+        other: パッケージ商品ごとに均一の比率
+      spree/calculator/shipping/price_sack:
+        one: 袋値段
+        other: 袋値段
+      spree/calculator/tiered_flat_rate:
+        one: 列の均一料金
+        other: 列の均一料金
+      spree/calculator/tiered_percent:
+        one: 列パーセント
+        other: 列パーセント
       spree/country:
         one: 国名
         other: 国名
@@ -230,12 +445,20 @@ ja:
       spree/customer_return:
         one: 返品
         other: 返品
+      spree/image:
+        one: 画像
+        other: 画像
       spree/inventory_unit:
         one: 在庫品単位
         other: 在庫品単位
+      spree/legacy_user:
+        one: ユーザー
+        other: ユーザー
       spree/line_item:
         one: 品目
         other: 品目
+      spree/log_entry:
+        other: ログエントリー
       spree/option_type:
         one: オプション
         other: オプション
@@ -251,9 +474,13 @@ ja:
       spree/payment_method:
         one: 支払い方法
         other: 支払い方法
+      spree/price:
+        one: 価格
       spree/product:
         one: 商品
         other: 商品
+      spree/product_property:
+        other: 商品情報
       spree/promotion:
         one: プロモーション
         other: プロモーション
@@ -266,6 +493,9 @@ ja:
       spree/prototype:
         one: 原型
         other: 原型
+      spree/refund:
+        one: 払い戻し
+        other: 返金
       spree/refund_reason:
         one: 返金理由
         other: 返金理由
@@ -308,6 +538,11 @@ ja:
       spree/stock_transfer:
         one: 在庫移動
         other: 在庫移動
+      spree/store:
+        one: ストア
+      spree/store_credit_category:
+        one: カテゴリー
+        other: カテゴリー
       spree/tax_category:
         one: 税区分
         other: 税区分
@@ -335,6 +570,9 @@ ja:
       spree/page:
         one: 特集ページ
         other: 特集ページ
+      user:
+        one: ユーザー
+        other: ユーザー
   devise:
     confirmations:
       confirmed: アカウントが正常に確認されました。ログインしました。
@@ -391,16 +629,20 @@ ja:
     account_updated: アカウントが更新されました。
     action: アクション
     actions:
+      add: 追加
       cancel: キャンセル
       continue: 続ける
       create: 作成
+      delete: 削除
       destroy: 削除
       edit: 編集
       list: リスト
       listing: 一覧
       new: 新規
       refund: 返金
+      remove: 削除
       save: 保存
+      split: 分割
       update: 更新
     activate: アクティベートする
     active: 有効
@@ -432,6 +674,9 @@ ja:
     adjustment_total: 調整（値引き・追加料金）総額
     adjustments: 調整（値引き・追加料金）
     admin:
+      promotions:
+        form:
+          general: 一般
       tab:
         configuration: 設定
         option_types: オプション
@@ -521,9 +766,11 @@ ja:
     calculator_settings_warning: 計算方法のタイプを変更する場合は、計算方法の設定を編集する前に保存してください。
     cancel: キャンセル
     canceler: キャンセル者
+    canceled: キャンセル
     canceled_at: にキャンセル
     cannot_create_payment_without_payment_methods: 支払い方法が選択されていないので、支払いを行うことができません
     cannot_create_customer_returns: まだこの注文は発送単位がないため、顧客返金を作成できません。
+    cannot_create_payment_link: まず支払い方法を定義してください。
     cannot_create_returns: 未発送の注文品に対して返品が出来ません。注文をキャンセルし注文を作り直すか問い合わせて下さい。
     cannot_perform_operation: 処理出来ませんでした
     cannot_set_shipping_method_without_address: 顧客詳細が提供されるまで発送方法を設定できません。
@@ -648,6 +895,7 @@ ja:
     doesnt_track_inventory: 在庫をトラッキングしません。
     edit: 編集
     editing_country:
+    edit_refund_reason:
     editing_adjustment_reason:
     editing_option_type:
     editing_payment_method:
@@ -768,6 +1016,7 @@ ja:
       this_file_language: 日本語 (ja-JP)
       translations: 翻訳
     icon: アイコン
+    identifier: 数量
     image: 画像
     images: 画像
     implement_eligible_for_return:
@@ -796,6 +1045,10 @@ ja:
     inventory_adjustment: 在庫調整
     inventory_error_flash_for_insufficient_quantity: カート内のアイテムが販売不可となりました。
     inventory_state: 在庫状態
+    inventory_states:
+      canceled: キャンセル
+      returned: 返品済み
+      shipped: 配送済み
     is_not_available_to_shipment_address: はこの配達先では発送出来ません。
     iso_name: ISO名
     item: アイテム
@@ -911,6 +1164,7 @@ ja:
     no_results: 検索結果がありませんでした。
     no_rules_added: ルールが追加されていません
     no_resource_found: "%{resource}が見つかりませんでした。"
+    no_resource_found_link: 新規追加
     no_returns_found: 返品がありません。
     no_shipping_method_selected: 配送方法が選択されていません。
     no_state_changes: まだ状態変化がありません。
@@ -931,6 +1185,7 @@ ja:
       variant_deleted: 種類を削除しました
       variant_not_deleted: 種類を削除することが出来ませんでした
     num_orders:
+    number: 注文番号
     on_hand: 入荷数
     open: 公開
     open_all_adjustments: すべての調整を開く
@@ -968,6 +1223,8 @@ ja:
         subtotal: '小計:'
         thanks: ご利用ありがとうございました。
         total: '合計: '
+      inventory_cancellation:
+        dear_customer: お客様へ
     order_not_found: 注文を見つけることができませんでした。リトライしていただくようお願いいたします。
     order_number: 注文 %{number}
     order_processed_successfully: 注文が完了しました。
@@ -1330,6 +1587,15 @@ ja:
     stock_transfers: 在庫移動
     stop: 終わり
     store: ストア
+    store_credit:
+      display_action:
+        adjustment: 調整（値引き・追加料金）
+        admin:
+          authorize: 認証しました。
+        credit: 債権
+        void: 債権
+    store_credit_category:
+      default: 初期設定
     street_address: 住所
     street_address_2: 住所の続き
     subtotal: 合計
@@ -1356,6 +1622,7 @@ ja:
       label: 注文はこれらの分類単位を含まなければなりません。
       match_all: すべて
       match_any: 最低一つ
+      match_none: なし
     taxonomies: ジャンルツリー
     taxonomy: ジャンルツリー
     taxonomy_edit: ジャンルツリーを編集する
@@ -1412,6 +1679,9 @@ ja:
     use_new_cc_or_payment_method: 新しいカードを利用 / 支払い方法
     use_s3: 商品画像の保存にAmazon S3を使用する
     user: ユーザー
+    user_role_rule:
+      match_all: すべて
+      match_any: 最低一つ
     user_rule:
       choose_users: ユーザーの選択
     users: ユーザー

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -468,6 +468,9 @@ ja:
       spree/order:
         one: 注文
         other: 注文
+      spree/page:
+        one: 特集ページ
+        other: 特集ページ
       spree/payment:
         one: 支払い
         other: 支払い
@@ -529,12 +532,12 @@ ja:
       spree/state_change:
         one: 状態変化
         other: 状態変化
-      spree/stock_movement:
-        one: 在庫遷移
-        other: 在庫遷移
       spree/stock_location:
         one: 在庫場所
         other: 在庫場所
+      spree/stock_movement:
+        one: 在庫遷移
+        other: 在庫遷移
       spree/stock_transfer:
         one: 在庫移動
         other: 在庫移動
@@ -567,9 +570,6 @@ ja:
       spree/zone:
         one: ゾーン
         other: ゾーン
-      spree/page:
-        one: 特集ページ
-        other: 特集ページ
       user:
         one: ユーザー
         other: ユーザー
@@ -678,29 +678,29 @@ ja:
         form:
           general: 一般
       tab:
+        areas: ゾーン
+        checkout: 決済
         configuration: 設定
+        general: 一般設定
         option_types: オプション
         orders: 注文
         overview: 概要
+        payments: 支払い方法
         products: 商品
-        promotions: プロモーション
         promotion_categories: プロモーションカテゴリ
+        promotions: プロモーション
         properties: 属性
         prototypes: 原型
         reports: レポート
-        taxonomies: ジャンルツリー
-        taxons: ジャンル単位
-        users: ユーザー
         settings: 設定
-        general: 一般設定
-        payments: 支払い方法
-        areas: ゾーン
-        taxes: 税金
-        checkout: 決済
         shipping: 配送方法
         stock: 在庫
         stock_items: 在庫品
         stock_transfers: 在庫移動
+        taxes: 税金
+        taxonomies: ジャンルツリー
+        taxons: ジャンル単位
+        users: ユーザー
       user:
         account: アカウント
         addresses: 住所
@@ -732,8 +732,8 @@ ja:
     analytics_trackers: Google アナリティクス
     and: と
     approve: 承認
-    approver: 承認者
     approved_at: 承認日時
+    approver: 承認者
     are_you_sure: 本当によろしいですか?
     are_you_sure_delete: 削除しますか?
     associated_adjustment_closed: 関連された調整が閉じられると、再計算しなくなります。それを開きますか？
@@ -745,14 +745,14 @@ ja:
     avs_response: AVS レスポンス
     back: 戻る
     back_end: バックエンド
-    backordered: 入荷待ち
-    back_to_resource_list: "%{resource} に戻る"
     back_to_payment: 支払いに戻る
+    back_to_resource_list: "%{resource} に戻る"
     back_to_rma_reason_list: 商品返品確認番号リストに戻る
     back_to_store: ショップに戻る
     back_to_users_list: ユーザー一覧に戻る
     backorderable: 入荷待ち可能
     backorderable_default: 入荷待ちデフォルト
+    backordered: 入荷待ち
     backorders_allowed: 入荷待ち許可
     balance_due: 未払額
     base_amount: 基準量
@@ -765,12 +765,12 @@ ja:
     calculator: 計算方法
     calculator_settings_warning: 計算方法のタイプを変更する場合は、計算方法の設定を編集する前に保存してください。
     cancel: キャンセル
-    canceler: キャンセル者
     canceled: キャンセル
     canceled_at: にキャンセル
-    cannot_create_payment_without_payment_methods: 支払い方法が選択されていないので、支払いを行うことができません
+    canceler: キャンセル者
     cannot_create_customer_returns: まだこの注文は発送単位がないため、顧客返金を作成できません。
     cannot_create_payment_link: まず支払い方法を定義してください。
+    cannot_create_payment_without_payment_methods: 支払い方法が選択されていないので、支払いを行うことができません
     cannot_create_returns: 未発送の注文品に対して返品が出来ません。注文をキャンセルし注文を作り直すか問い合わせて下さい。
     cannot_perform_operation: 処理出来ませんでした
     cannot_set_shipping_method_without_address: 顧客詳細が提供されるまで発送方法を設定できません。
@@ -885,18 +885,18 @@ ja:
     deleted_variants_present: 注文の商品のいくつかが既に購入不可となっています。
     delivery: 配送/お届け
     depth: 奥行き
-    details: 詳細
     description: 説明
     destination: 目的地
     destroy: 破壊する
+    details: 詳細
     discount_amount: 割引額
     dismiss_banner: いいえ。結構です！興味ありません。再びこのメッセージを表示しないでください。
     display: 表示
     doesnt_track_inventory: 在庫をトラッキングしません。
     edit: 編集
-    editing_country:
     edit_refund_reason:
     editing_adjustment_reason:
+    editing_country:
     editing_option_type:
     editing_payment_method:
     editing_product: 商品の編集
@@ -904,7 +904,6 @@ ja:
     editing_promotion_category:
     editing_property:
     editing_prototype:
-    edit_refund_reason:
     editing_refund_reason:
     editing_reimbursement:
     editing_reimbursement_type:
@@ -965,22 +964,21 @@ ja:
         user:
           signup: ユーザー登録
     exceptions:
-      count_on_hand_setter: 手動で手計算をセットできません。それはrecalculate_count_on_handコールバックで自動的にセットされます。`update_column(:count_on_hand,
-        value)`を代わりに利用してください。
+      count_on_hand_setter: 手動で手計算をセットできません。それはrecalculate_count_on_handコールバックで自動的にセットされます。`update_column(:count_on_hand, value)`を代わりに利用してください。
     exchange_for: に変換
-    expedited_exchanges_warning: 指定したどんな変換も保存後すぐに顧客に反映されます。もし顧客が元の商品を%{days_window}日以内に返さなかった場合、顧客はすべての量の商品に決済されます。
     excl: excl.
+    existing_shipments: 現在の発送
+    expedited_exchanges_warning: 指定したどんな変換も保存後すぐに顧客に反映されます。もし顧客が元の商品を%{days_window}日以内に返さなかった場合、顧客はすべての量の商品に決済されます。
     expiration: 有効期限
     extension: 拡張
-    existing_shipments: 現在の発送
     failed_payment_attempts: 支払いに失敗
     filename: ファイル名
     fill_in_customer_info: 顧客情報を埋めてください。
     filter: 検索
     filter_results: 検索結果
     finalize: 確定
-    find_a_taxon: ジャンル単位を見つける
     finalized: 確定済み
+    find_a_taxon: ジャンル単位を見つける
     first_item: 一品目の値段
     first_name: 名前（名）
     first_name_begins_with: 名前（名）が以下の文字列で始まる
@@ -1026,10 +1024,10 @@ ja:
     included_in_price: 価格に含まれる
     included_price_validation: はデフォルトのタックスゾーンを設定しない限り選択できません。
     incomplete: 不完全
-    info_product_has_multiple_skus: 'この商品は%{count}個あります:'
     info_number_of_skus_not_shown:
       one: ともう一つ
       other: と %{count}個
+    info_product_has_multiple_skus: 'この商品は%{count}個あります:'
     instructions_to_reset_password: 下のフォームを入力してからパスワードの再設定方法の説明がメールで送信されます。
     insufficient_stock: 在庫が十分ではありません。残り%{on_hand}個です。
     insufficient_stock_lines_present: いくつかの注文商品のが不十分です。
@@ -1084,7 +1082,6 @@ ja:
     location: 位置
     lock: ロック
     log_entries: ログエントリー
-    logs: ログ
     logged_in_as: ログイン
     logged_in_succesfully: ログインに成功しました
     logged_out: ログアウトしました。
@@ -1093,6 +1090,7 @@ ja:
     login_failed: ログイン認証失敗
     login_name: ログイン名
     logout: ログアウト
+    logs: ログ
     look_for_similar_items: 似た商品を探す
     make_refund: 返金する
     make_sure_the_above_reimbursement_amount_is_correct: 上記の返品量が正しいことを確認してください。
@@ -1122,9 +1120,9 @@ ja:
     name_or_sku: 品名もしくは品番
     new: 新規
     new_adjustment: 新規の値引き・追加請求
+    new_country: 新規国
     new_customer: 新規顧客
     new_customer_return: 新規顧客返品
-    new_country: 新規国
     new_image: 新規画像
     new_option_type: 新規オプション
     new_order: 新規注文
@@ -1138,12 +1136,12 @@ ja:
     new_prototype: 新規原型
     new_refund: 新規返金
     new_refund_reason: 新規返金理由
-    new_rma_reason: 新規RMA理由
     new_return_authorization: 新規返品依頼
+    new_rma_reason: 新規RMA理由
     new_role: 新規役割
+    new_shipment_at_location:
     new_shipping_category: 新規配送カテゴリー
     new_shipping_method: 新規配送方法
-    new_shipment_at_location:
     new_state: 新規都道府県（州）
     new_stock_location: 新規在庫場所
     new_stock_movement: 新規在庫移動
@@ -1161,11 +1159,11 @@ ja:
     no_payment_found: 支払いなし
     no_pending_payments: 延滞なし
     no_products_found: 商品が見付かりませんでした。
-    no_results: 検索結果がありませんでした。
-    no_rules_added: ルールが追加されていません
     no_resource_found: "%{resource}が見つかりませんでした。"
     no_resource_found_link: 新規追加
+    no_results: 検索結果がありませんでした。
     no_returns_found: 返品がありません。
+    no_rules_added: ルールが追加されていません
     no_shipping_method_selected: 配送方法が選択されていません。
     no_state_changes: まだ状態変化がありません。
     no_tracking_present: トラッキング詳細が提供されていません。
@@ -1262,8 +1260,8 @@ ja:
     payment_could_not_be_created: 支払いを作成できませんでした。
     payment_information: 支払い情報
     payment_method: 支払い方法
-    payment_methods: 支払い方法
     payment_method_not_supported: その支払い方法はサポートされていません。他のものを選択してください。
+    payment_methods: 支払い方法
     payment_processing_failed: 決済が失敗しました。入力した情報を確認してから再び決済を行ってみて下さい。
     payment_processor_choose_banner_text: もし決済処理会社の選択でお困りでしたら、どうぞ
     payment_processor_choose_link: こちらへ
@@ -1280,18 +1278,18 @@ ja:
       void: 無効
     payment_updated: 支払いが更新されました。
     payments: 支払い方法
+    pending: 未決定
     percent: パーセント
     percent_per_item: アイテムごとのパーセント
     permalink: パーマリンク
-    pending: 未決定
     phone: 電話番号
     place_order: 注文を送信する
     please_define_payment_methods: まず支払い方法を定義してください。
     please_enter_reasonable_quantity: 適切な量を入力してください。
     populate_get_error: 問題が発生しました。もう一度追加してみてください。
     powered_by: Powered by
-    pre_tax_refund_amount: 税前返金料
     pre_tax_amount: 税前料金
+    pre_tax_refund_amount: 税前返金料
     pre_tax_total: 税前合計
     preferred_reimbursement_type: 望ましい返済方法
     presentation: 表示名
@@ -1317,7 +1315,6 @@ ja:
         manual: 手動で選択
     products: 商品
     promotion: プロモーション
-    promotionable: プロモーション可能
     promotion_action: プロモーションアクション
     promotion_action_types:
       create_adjustment:
@@ -1358,17 +1355,18 @@ ja:
       product:
         description: 注文に特定の商品を含む
         name: 商品
+      taxon:
+        description: 指定したジャンル単位のみ
+        name: ジャンル単位
       user:
         description: 特定のユーザー限定
         name: ユーザー
       user_logged_in:
         description: ログイン中のユーザー限定
         name: ログイン中のユーザー
-      taxon:
-        description: 指定したジャンル単位のみ
-        name: ジャンル単位
-    promotions: プロモーション
     promotion_uses: プロモーション
+    promotionable: プロモーション可能
+    promotions: プロモーション
     propagate_all_variants:
     properties: 属性
     property: 属性
@@ -1399,6 +1397,16 @@ ja:
     reimburse: 払い戻す
     reimbursed: 払い戻し済み
     reimbursement: 払い戻し
+    reimbursement_mailer:
+      reimbursement_email:
+        days_to_send: 交換待ちの商品を送り返すのに%{days}必要です。
+        dear_customer: お客様
+        exchange_summary: 交換概要
+        for: for
+        instructions: 返品が実行されました。
+        refund_summary: 返品概要
+        subject: 返品通知
+        total_refunded: '返金合計: %{total}'
     reimbursement_perform_failed: 払い戻しが実行できませんでした。 %{error}
     reimbursement_status: 払い戻しステータス
     reimbursement_type: 払い戻しタイプ
@@ -1430,16 +1438,6 @@ ja:
     return_item_time_period_ineligible: 返品は期限切れです。
     return_items: 返品
     return_items_cannot_be_associated_with_multiple_orders: 返品商品は複数の注文の注文と関連づけることはできません。
-    reimbursement_mailer:
-      reimbursement_email:
-        days_to_send: 交換待ちの商品を送り返すのに%{days}必要です。
-        dear_customer: お客様
-        exchange_summary: 交換概要
-        for: for
-        instructions: 返品が実行されました。
-        refund_summary: 返品概要
-        subject: 返品通知
-        total_refunded: '返金合計: %{total}'
     return_number: 返品番号
     return_quantity: 返品数
     returned: 返品済み
@@ -1469,9 +1467,9 @@ ja:
     secure_connection_type: 接続保護のタイプ
     security_settings: セキュリティの設定
     select: 選択
-    select_from_prototype: 原型から選択
     select_a_return_authorization_reason: 返品認証の理由を選択してください
     select_a_stock_location: 在庫場所の選択
+    select_from_prototype: 原型から選択
     select_stock: 在庫の選択
     selected_quantity_not_available: "%{item}の選択は利用不可です。"
     send_copy_of_all_mails_to: 全てのメールのコピーをこの宛先に送る
@@ -1502,8 +1500,8 @@ ja:
       pending: 配送準備中
       ready: 配送可能
       shipped: 配送済み
-    shipment_transfer_success: 種別の移動に成功しました。
     shipment_transfer_error: 種別の移動中にエラーが発生しました。
+    shipment_transfer_success: 種別の移動に成功しました。
     shipments: 配送
     shipped: 発送済
     shipping: 送料
@@ -1538,7 +1536,6 @@ ja:
     start: 始め
     state: 都道府県（州）
     state_based: 都道府県（州）による区別
-    states: 都道府県（州）
     state_machine_states:
       accepted: 受付
       address: 住所
@@ -1559,9 +1556,9 @@ ja:
       given_to_customer: ふさわしい顧客
       invalid: 不正
       manual_intervention_required: 手動介入が必要
+      on_hand: 主導
       open: 公開
       order: 注文
-      on_hand: 主導
       payment: 支払い
       pending: 停止
       processing: 処理中
@@ -1571,6 +1568,7 @@ ja:
       returned: 返品
       shipped: 配送済み
       void: 空
+    states: 都道府県（州）
     states_required: 必須
     status: 状況
     stock: 在庫
@@ -1608,10 +1606,10 @@ ja:
     successfully_updated: "%{resource}が更新されました!"
     summary: 概要
     tax: 税金
-    tax_included: 税金 (incl.)
     tax_categories: 税金カテゴリー
     tax_category: 税金カテゴリー
     tax_code: 税金コード
+    tax_included: 税金 (incl.)
     tax_rate_amount_explanation: 税率は5%のとき、0.05と入力します。
     tax_rates: 税率
     taxon: ジャンル単位
@@ -1641,9 +1639,9 @@ ja:
     there_were_problems_with_the_following_fields: 以下の入力欄で問題がありました
     this_order_has_already_received_a_refund: この注文は既に返金受け取り済みです。
     thumbnail: サムネイル
-    tiers: 列
     tiered_flat_rate: 列の均一料金
     tiered_percent: 列パーセント
+    tiers: 列
     time: 時間
     to_add_variants_you_must_first_define: 種類を追加するには、まず以下を定義する必要があります。
     total: 合計
@@ -1686,17 +1684,17 @@ ja:
       choose_users: ユーザーの選択
     users: ユーザー
     validation:
-      unpaid_amount_not_zero: '量を完全に返品できません。 Still due: %{amount}'
       cannot_be_less_than_shipped_units: 配送ユニットの個数より小さくはできません
       cannot_destroy_line_item_as_inventory_units_have_shipped: いくつかの在庫が発送されたため項目を削除できません。
       exceeds_available_stock: 可能な在庫数を上回っています。項目の個数が正しく入力されていることを確認してください。
       is_too_large: 要求された量は在庫を超えています。
       must_be_int: 整数であることが必要です
       must_be_non_negative: 0以上の数字が必要です
+      unpaid_amount_not_zero: '量を完全に返品できません。 Still due: %{amount}'
     value: 値
     variant: 種類
-    variant_search_placeholder: 品名もしくは品番[SKU]
     variant_placeholder: 種類プレイスホルダ
+    variant_search_placeholder: 品名もしくは品番[SKU]
     variants: 種類
     version: バージョン
     void: 無効


### PR DESCRIPTION
Recent changes made to admin translations in solidus moved many of the keys. This was done to better use the ActiveModel translation conventions.

I wrote a [script](https://github.com/StemboltHQ/solidus_i18n_convert) that scans through the locale files in solidus_i18n looking for missing keys when compared to `en.yml` in core. Since these translations are just moved, the script attempts to make the same moves in this locale as were made for english.

Reviews would be appreciated to find any blatant mistranslations.
