### PR TITLE
Convert it translations from solidus 1.2 -> 1.3

### DIFF
--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -11,6 +11,7 @@ it:
         phone: Telefono
         state: Provincia
         zipcode: CAP
+        company: Azienda
       spree/calculator/tiered_flat_rate:
         preferred_base_amount: Importo Base
         preferred_tiers: Livelli
@@ -23,6 +24,7 @@ it:
         iso_name: Nome ISO
         name: Nome
         numcode: Codice ISO
+        states_required: Stati Necessari
       spree/credit_card:
         base: ''
         cc_type: Tipologia
@@ -31,18 +33,23 @@ it:
         number: Numero
         verification_value: Codice di Verifica
         year: Anno
+        card_code: Codice Carta
+        expiration: Scadenza
       spree/inventory_unit:
         state: Stato
       spree/line_item:
         price: Prezzo
         quantity: Quantità
+        description: Descrizione dell'articolo
+        name: Nome
+        total: Prezzo totale
       spree/option_type:
         name: Nome
         presentation: Presentazione
       spree/order:
         checkout_complete: Checkout Completato
         completed_at: Completato il
-        considered_risky: A Rischio
+        considered_risky: A rischio
         coupon_code: Codice Coupon
         created_at: Data Ordine
         email: E-Mail Cliente
@@ -54,7 +61,13 @@ it:
         special_instructions: Istruzioni Aggiuntive
         state: Stato
         total: Totale
-        considered_risky: A rischio
+        additional_tax_total: Tassazione
+        approved_at: Approvato il
+        approver_id: Approvatore
+        canceled_at: Annullato il
+        canceler_id: Annullatore
+        included_tax_total: Tassa (incl.)
+        shipment_total: Totale Spedizione
       spree/order/bill_address:
         address1: Indirizzo di fatturazione
         city: Città di fatturazione
@@ -73,8 +86,15 @@ it:
         zipcode: CAP indirizzo di spedizione
       spree/payment:
         amount: Quantità
+        response_code: ID transazione
+        state: Stato Pagamento
       spree/payment_method:
         name: Nome
+        active: Attivo
+        auto_capture: Riscossione Automatica
+        description: Descrizione
+        display_on: Mostra
+        type: Fornitore
       spree/product:
         available_on: Disponibile dal
         cost_currency: Valuta Costo
@@ -85,6 +105,16 @@ it:
         on_hand: Disponibilità
         shipping_category: Categoria di Spedizione
         tax_category: Categoria di Tassazione
+        depth: Profondità
+        height: Altezza
+        meta_description: Meta Description
+        meta_keywords: Meta Keywords
+        meta_title: Meta Title
+        price: Prezzo principale
+        promotionable: Promuovibile
+        slug: Slug
+        weight: Peso
+        width: Larghezza
       spree/promotion:
         advertise: Publicizza
         code: Codice
@@ -106,6 +136,7 @@ it:
         name: Nome
       spree/return_authorization:
         amount: Quantità
+        pre_tax_total: Totale al lordo delle tasse
       spree/role:
         name: Nome
       spree/state:
@@ -129,14 +160,22 @@ it:
       spree/tax_category:
         description: Descrizione
         name: Nome
+        is_default: Default
+        tax_code: Codice Tassa
       spree/tax_rate:
         amount: Tasso
         included_in_price: Incluso nel Prezzo
         show_rate_in_label: Mostra tasso nell'etichetta
+        name: Nome
       spree/taxon:
         name: Nome
         permalink: Permalink
         position: Posizione
+        description: Descrizione
+        icon: Icona
+        meta_description: Meta Description
+        meta_keywords: Meta Keywords
+        meta_title: Meta Title
       spree/taxonomy:
         name: Nome
       spree/user:
@@ -155,25 +194,138 @@ it:
       spree/zone:
         description: Descrizione
         name: Nome
+        default_tax: Zona di Tassazione di Default
+      spree/adjustment:
+        adjustable: Variabile
+        amount: Quantità
+        label: Descrizione
+        name: Nome
+        state: Stato
+        adjustment_reason_id: Ragione
+      spree/adjustment_reason:
+        active: Attivo
+        code: Codice
+        name: Nome
+        state: Stato
+      spree/carton:
+        tracking: Tracciamento
+      spree/customer_return:
+        number: Numero Reso
+        pre_tax_total: Totale al lordo delle tasse
+        total: Totale
+        reimbursement_status: Stato Rimborso
+        name: Nome
+      spree/image:
+        alt: Testo Alternativo
+        attachment: Nome del file
+      spree/legacy_user:
+        email: Email
+        password: Password
+        password_confirmation: Conferma Password
+      spree/option_value:
+        name: Nome
+        presentation: Presentazione
+      spree/product_property:
+        value: Valore
+      spree/refund:
+        amount: Quantità
+        description: Descrizione
+        refund_reason_id: Ragione
+      spree/refund_reason:
+        active: Attivo
+        name: Nome
+        code: Codice
+      spree/reimbursement:
+        number: Numero
+        reimbursement_status: Stato
+        total: Totale
+      spree/reimbursement/credit:
+        amount: Quantità
+      spree/reimbursement_type:
+        name: Nome
+        type: Tipo
+      spree/return_item:
+        acceptance_status: Stato Accettazione
+        acceptance_status_errors: Errori Accettazione
+        charged: Addebitato
+        exchange_variant: Cambio per
+        inventory_unit_state: Stato
+        override_reimbursement_type_id: Override Tipologia Rimborso
+        preferred_reimbursement_type_id: Tipologia di rimborso preferita
+        reception_status:
+        return_reason: Ragione
+        total: Totale
+      spree/return_reason:
+        name: Nome
+        active: Attivo
+        memo: Memo
+        number: Numero RMA
+        state: Stato
+      spree/shipping_category:
+        name: Nome
+      spree/shipment:
+        tracking: Codice Tracciamento
+      spree/shipping_method:
+        admin_name: Nome Interno
+        code: Codice
+        display_on: Mostra
+        name: Nome
+        tracking_url: URL Tracciamento
+      spree/shipping_rate:
+        tax_rate: Aliquota
+        amount: Quantità
+      spree/store_credit:
+        amount: Quantità
+        memo: Memo
+      spree/store_credit_event:
+        action: Azione
+      spree/stock_item:
+        count_on_hand: Disponibilità
+      spree/stock_location:
+        admin_name: Nome Interno
+        active: Attivo
+        address1: Indirizzo
+        address2: Indirizzo (agg.)
+        backorderable_default: Ordinabile di default
+        city: Città
+        code: Codice
+        country_id: Paese
+        default: Default
+        internal_name: Nome Interno
+        name: Nome
+        phone: Telefono
+        propagate_all_variants: Propaga a tutte le varianti
+        state_id: Stato
+        zipcode: Cap
+      spree/stock_movement:
+        action: Azione
+        quantity: Quantità
+      spree/stock_transfer:
+        created_at: Creato Il
+        description: Descrizione
+        tracking_number: Codice Tracciamento
+      spree/tracker:
+        analytics_id: Analytics ID
+        active: Attivo
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number: 'Le chiavi dei livelli devono tutti essere numeri maggiori di 0'
+              keys_should_be_positive_number: Le chiavi dei livelli devono tutti essere numeri maggiori di 0
             preferred_tiers:
               should_be_hash: deve essere un Hash
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number: 'Le chiavi dei livelli devono tutti essere numeri maggiori di 0'
-              values_should_be_percent: "I valori dei livelli devono tutti essere percentuali tra 0% e 100%"
+              keys_should_be_positive_number: Le chiavi dei livelli devono tutti essere numeri maggiori di 0
+              values_should_be_percent: I valori dei livelli devono tutti essere percentuali tra 0% e 100%
             preferred_tiers:
               should_be_hash: deve essere un Hash
         spree/classification:
           attributes:
             taxon_id:
-              already_linked: "è già collegato a questo prodotto"
+              already_linked: è già collegato a questo prodotto
         spree/credit_card:
           attributes:
             base:
@@ -318,11 +470,29 @@ it:
         other: Zone
   activemodel:
     attributes:
+      spree/adjustment:
+        one: Variazione
+        other: Variazioni
+      spree/calculator:
+        one: Calcolatore
+      spree/legacy_user:
+        one: Utente
+        other: Utenti
+      spree/log_entry:
+        other: Voci Log
       spree/order_cancellations:
         quantity: Quantità
         state: Stato
         shipment: Spedizione
         cancel: Annulla
+      spree/product_property:
+        other: Proprietà del prodotto
+      spree/refund:
+        one: Rimborso
+        other: Rimborsi
+      spree/store_credit_category:
+        one: Categoria
+        other: Categorie
   devise:
     confirmations:
       confirmed: Il tuo account è stato confermato. Hai effettuato il login.
@@ -343,8 +513,8 @@ it:
       unlock_instructions:
         subject: Istruzioni per Sbloccare
     oauth_callbacks:
-      failure: "Non è stato possibile autorizzarti da %{kind} perché %{reason}."
-      success: "Autorizzato correttamente dall'account %{kind}"
+      failure: Non è stato possibile autorizzarti da %{kind} perché %{reason}.
+      success: Autorizzato correttamente dall'account %{kind}
     unlocks:
       send_instructions: Riceverai un'email con le istruzioni per sbloccare il tuo account entro pochi minuti.
       unlocked: Il tuo account è stato sbloccato con successo. Hai effettuato il login.
@@ -355,7 +525,7 @@ it:
         updated: Hai modificato la tua password con successo. Hai effettuato il login.
     user_registrations:
       destroyed: Ciao! Il tuo account è stato eliminato con successo. Speriamo di rivederti presto.
-      inactive_signed_up: "Ti sei registrato con successo. Purtroppo non abbiamo potuto effettuare il login perché il tuo account è %{reason}"
+      inactive_signed_up: Ti sei registrato con successo. Purtroppo non abbiamo potuto effettuare il login perché il tuo account è %{reason}
       signed_up: Benvenuto! Hai effettuato il login con successo.
       updated: Hai aggiornato il tuo account con successo.
     user_sessions:
@@ -363,7 +533,7 @@ it:
       signed_out: Hai effettuato il logout con successo.
   errors:
     messages:
-      already_confirmed: "è già stato confermato"
+      already_confirmed: è già stato confermato
       not_found: non trovato
       not_locked: non era bloccato
       not_saved:
@@ -390,6 +560,11 @@ it:
       refund: Rimborso
       save: Salva
       update: Aggiorna
+      add: Aggiungi
+      delete: Elimina
+      remove: Rimuovi
+      ship: spedisci
+      split: Diviso
     activate: Attiva
     active: Attivo
     add: Aggiungi
@@ -434,9 +609,8 @@ it:
         overview: Quadro generale
         payments: Pagamenti
         products: Prodotti
-        promotion_categories: Categorie Promozione
-        promotions: Promozioni
         promotion_categories:
+        promotions: Promozioni
         properties: Proprietà
         prototypes: Prototipi
         reports: Report
@@ -450,13 +624,19 @@ it:
         taxonomies: Tassonomie
         taxons: Taxon
         users: Utenti
+        checkout: Checkout
+        general: Generale
+        payments: Pagamenti
+        settings: Impostazioni
+        shipping: Spedizione
+        stock: Stock
       user:
         account: Account
         addresses: Indirizzi
         items: Articoli
         items_purchased: Articoli Acquistati
         order_history: Storia Ordini
-        order_num: "Ordine #"
+        order_num: 'Ordine #'
         orders: Ordini
         user_information: Informazioni Utente
         store_credit: Credito
@@ -490,9 +670,9 @@ it:
     analytics_desc_header_1: Spree Analytics
     analytics_desc_header_2: Analytics in tempo reale integrato nella tua dashboard di Spree
     analytics_desc_list_1: Ottieni informazioni sulle vendite in tempo reale
-    analytics_desc_list_2: "È richiesto un account gratuito Spree per l'attivazione"
+    analytics_desc_list_2: È richiesto un account gratuito Spree per l'attivazione
     analytics_desc_list_3: Assolutamente nessun codice da installare
-    analytics_desc_list_4: "È completamente gratuito!"
+    analytics_desc_list_4: È completamente gratuito!
     analytics_trackers: Tracker Analytics
     and: e
     api:
@@ -508,7 +688,7 @@ it:
     are_you_sure: Sei sicuro?
     are_you_sure_delete: Sei sicuro di voler eliminare questo record?
     associated_adjustment_closed: La variazione associata è chiusa e non verrà ricalcolata. Vuoi riaprirla?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Autorizzazione Fallita
     authorized: Autorizzato
     auto_capture: Riscossione Automatica
@@ -550,7 +730,7 @@ it:
     both: Entrambi
     calculated_reimbursements: Rimborsi Calcolati
     calculator: Calcolatore
-    calculator_settings_warning: "Se stai cambiando la tipologia di calcolatore, devi prima salvare per modificare le impostazioni del calcolatore"
+    calculator_settings_warning: Se stai cambiando la tipologia di calcolatore, devi prima salvare per modificare le impostazioni del calcolatore
     cancel: annulla
     cancel_inventory: Annulla movimento
     canceled: annullato
@@ -571,7 +751,7 @@ it:
     cart: Carrello
     cart_subtotal:
       one: Subtotale (1 articolo)
-      other: "Subtotale (%{count} articoli)"
+      other: Subtotale (%{count} articoli)
     categories: Categorie
     category: Categoria
     charged: Addebitato
@@ -674,7 +854,7 @@ it:
     default_tax_zone: Zona di Tassazione di Default
     delete: Elimina
     delete_from_taxon: Rimuovi dalla Taxon
-    deleted_variants_present:  Alcune linee di questo ordine hanno prodotti che non sono più disponibili.
+    deleted_variants_present: Alcune linee di questo ordine hanno prodotti che non sono più disponibili.
     delivery: Consegna
     depth: Profondità
     description: Descrizione
@@ -682,7 +862,7 @@ it:
     destroy: Elimina
     details: Dettagli
     discount_amount: Importo dello sconto
-    dismiss_banner: "No, grazie! Non sono interessato, non mostrare più questo messaggio"
+    dismiss_banner: No, grazie! Non sono interessato, non mostrare più questo messaggio
     display: Mostra
     display_currency: Mostra valuta
     doesnt_track_inventory: Non tiene traccia dell'inventario
@@ -701,10 +881,10 @@ it:
     eligibility_errors:
       messages:
         has_excluded_product: Il carrello contiene un prodotto che non permette l'applicazione di questo codice coupon.
-        item_total_less_than: "Questo codice coupon non può essere applicato a ordini di importo inferiore a %{amount}."
-        item_total_less_than_or_equal: "Questo codice coupon non può essere applicato a ordini di importo inferiore o uguale a %{amount}."
-        item_total_more_than: "Questo codice coupon non può essere applicato a ordini di importo maggiore di %{amount}."
-        item_total_more_than_or_equal: "Questo codice coupon non può essere applicato a ordini di importo maggiore o uguale di %{amount}."
+        item_total_less_than: Questo codice coupon non può essere applicato a ordini di importo inferiore a %{amount}.
+        item_total_less_than_or_equal: Questo codice coupon non può essere applicato a ordini di importo inferiore o uguale a %{amount}.
+        item_total_more_than: Questo codice coupon non può essere applicato a ordini di importo maggiore di %{amount}.
+        item_total_more_than_or_equal: Questo codice coupon non può essere applicato a ordini di importo maggiore o uguale di %{amount}.
         limit_once_per_user: Questo codice coupon può essere usato solamente una volta per utente.
         missing_product: Questo codice coupon non può essere applicato poiché non hai nel carrello tutti i prodotti necessari.
         missing_taxon: Devi aggiungere un prodotto da tutte le categorie appropriate prima di applicare questo codice coupon.
@@ -725,7 +905,7 @@ it:
       messages:
         could_not_create_taxon: Non è possibile creare il taxon
         no_payment_methods_available: Non ci sono metodi di pagamenti configurati per questo ambiente
-        no_shipping_methods_available: "Non ci sono metodi di spedizione disponibili per l'indirizzo scelto, prova ancora."
+        no_shipping_methods_available: Non ci sono metodi di spedizione disponibili per l'indirizzo scelto, prova ancora.
     errors_prohibited_this_record_from_being_saved:
       one: un errore non ha permesso di salvare questo record
       other: "%{count} errori non hanno permesso di salvare questo record"
@@ -744,11 +924,11 @@ it:
         user:
           signup: Registrazione dell'utente
     exceptions:
-      count_on_hand_setter: 'Non è possibile impostare la disponibilità manualmente dato che è calcolata automaticamente dalla callback "recalculate_count_on_hand". Per favore usa il metodo "update_column(:count_on_hand, value)".'
+      count_on_hand_setter: Non è possibile impostare la disponibilità manualmente dato che è calcolata automaticamente dalla callback "recalculate_count_on_hand". Per favore usa il metodo "update_column(:count_on_hand, value)".
     exchange_for: Cambio per
     excl: escl.
     existing_shipments: Spedizioni esistenti
-    expedited_exchanges_warning: "Ogni cambio specificato sarà spedito al cliente immediatamente dopo il salvataggio. Al cliente sarà addebitato l'importo completo dell'articolo se l'articolo originale non verrà restituito entro %{days_window} giorni."
+    expedited_exchanges_warning: Ogni cambio specificato sarà spedito al cliente immediatamente dopo il salvataggio. Al cliente sarà addebitato l'importo completo dell'articolo se l'articolo originale non verrà restituito entro %{days_window} giorni.
     expiration: Scadenza
     extension: Estensione
     failed_payment_attempts: Tentativi di Pagamento falliti
@@ -807,11 +987,11 @@ it:
     included_price_validation: non può essere selezionato senza aver impostato una Zona di Tassazione di Default
     incomplete: incompleto
     info_number_of_skus_not_shown:
-      one: "e un'altra"
-      other: "e altre %{count}"
-    info_product_has_multiple_skus: "Questo prodotto ha %{count} varianti:"
+      one: e un'altra
+      other: e altre %{count}
+    info_product_has_multiple_skus: 'Questo prodotto ha %{count} varianti:'
     instructions_to_reset_password: Per favore inserisci la tua email nel form sottostante
-    insufficient_stock: "Scorte insufficienti, ne rimangono solo %{on_hand}"
+    insufficient_stock: Scorte insufficienti, ne rimangono solo %{on_hand}
     insufficient_stock_lines_present: Alcune linee di questo ordine hanno quantità insufficiente.
     intercept_email_address: Intercetta indirizzo Email
     intercept_email_instructions: Sovrascrivi il destinatario dell'email con questo indirizzo.
@@ -991,22 +1171,30 @@ it:
     order_information: Informazioni sull'Ordine
     order_mailer:
       cancel_email:
-        dear_customer: "Gentile Cliente,\n"
+        dear_customer: 'Gentile Cliente,
+
+'
         instructions: Il tuo ordine è stato ANNULLATO. Per favore conserva queste informazioni per attestare l'annullamento.
-        order_summary_canceled: "Riassunto Ordine [ANNULLATO]"
+        order_summary_canceled: Riassunto Ordine [ANNULLATO]
         subject: Annullamento Ordine
-        subtotal: ! 'Subtotale:'
-        total: ! 'Totale Ordine:'
+        subtotal: 'Subtotale:'
+        total: 'Totale Ordine:'
       confirm_email:
-        dear_customer: "Caro Cliente,\n"
+        dear_customer: 'Caro Cliente,
+
+'
         instructions: Per favore rivedi queste informazioni e conservale come riferimento.
         order_summary: Riassunto Ordine
         subject: Conferma Ordine
-        subtotal: ! 'Subtotale:'
+        subtotal: 'Subtotale:'
         thanks: Grazie per il tuo ordine.
-        total: ! 'Totale Ordine:'
+        total: 'Totale Ordine:'
+      inventory_cancellation:
+        dear_customer: 'Gentile Cliente,
+
+'
     order_not_found: Non abbiamo trovato il tuo ordine. Per favore riprova ancora.
-    order_number: "Ordine %{number}"
+    order_number: Ordine %{number}
     order_processed_successfully: Il tuo ordine è stato processato con successo
     order_resumed: Ordine Riattivato
     order_state:
@@ -1022,7 +1210,7 @@ it:
       resumed: riattivato
       returned: restituito
     order_summary: Riassunto Ordine
-    order_sure_want_to: "Sei sicuro di voler %{event} questo ordine?"
+    order_sure_want_to: Sei sicuro di voler %{event} questo ordine?
     order_total: Totale Ordine
     order_updated: Ordine Aggiornato
     orders: Ordini
@@ -1031,7 +1219,7 @@ it:
     overview: Panoramica
     package_from: pacco da
     pagination:
-      next_page: "pagina successiva &raquo;"
+      next_page: pagina successiva &raquo;
       previous_page: "&laquo; pagina precedente"
       truncate: "&hellip;"
     password: Password
@@ -1045,8 +1233,8 @@ it:
     payment_method: Metodo di Pagamento
     payment_method_not_supported: Quel metodo di pagamento non è supportato. Per favore scegline un'altro.
     payment_methods: Metodi di Pagamento
-    payment_processing_failed: "Il pagamento non è stato processato correttamente, per favore controlla i dati inseriti"
-    payment_processor_choose_banner_text: "Se hai bisogno di assistenza nella scelta di un processore di pagamento, per favore visita"
+    payment_processing_failed: Il pagamento non è stato processato correttamente, per favore controlla i dati inseriti
+    payment_processor_choose_banner_text: Se hai bisogno di assistenza nella scelta di un processore di pagamento, per favore visita
     payment_processor_choose_link: la nostra pagina dei pagamenti
     payment_state: Stato Pagamento
     payment_states:
@@ -1076,7 +1264,7 @@ it:
     preferred_reimbursement_type: Tipologia di rimborso preferita
     presentation: Presentazione
     previous: Precedente
-    previous_state_missing: "n.a."
+    previous_state_missing: n.a.
     price: Prezzo
     price_range: Gamma di Prezzo
     price_sack: Costo imballaggio
@@ -1155,7 +1343,7 @@ it:
     prototype: Prototipo
     prototypes: Prototipi
     provider: Fornitore
-    provider_settings_warning: "Se stai cambiando la tipologia di fornitore, devi prima aver salvato le impostazioni del fornitore"
+    provider_settings_warning: Se stai cambiando la tipologia di fornitore, devi prima aver salvato le impostazioni del fornitore
     qty: Qtà
     quantity: Quantità
     quantity_returned: Quantità Restituita
@@ -1180,15 +1368,15 @@ it:
     reimbursement: Rimborso
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send: "Hai %{days} giorni per rispedire indietro gli articoli in attesa di cambio."
-        dear_customer: "Gentile Cliente,"
+        days_to_send: Hai %{days} giorni per rispedire indietro gli articoli in attesa di cambio.
+        dear_customer: Gentile Cliente,
         exchange_summary: Riassunto cambi
         for: per
         instructions: Il tuo rimborso è stato processato.
         refund_summary: Riassunto rimborso
         subject: Notifica di Rimborso
-        total_refunded: "Totale Rimborsato: %{total}"
-    reimbursement_perform_failed: "Il rimborso non può essere effettuato. Errore: %{error}"
+        total_refunded: 'Totale Rimborsato: %{total}'
+    reimbursement_perform_failed: 'Il rimborso non può essere effettuato. Errore: %{error}'
     reimbursement_status: Stato Rimborso
     reimbursement_type: Tipologia Rimborso
     reimbursement_type_override: Override Tipologia Rimborso
@@ -1240,7 +1428,7 @@ it:
     say_yes: Sì
     scope: Campo
     search: Cerca
-    search_results: "Risultati ricerca per '%{keywords}'"
+    search_results: Risultati ricerca per '%{keywords}'
     searching: Ricerca
     secure_connection_type: Tipologia Connessione Sicura
     security_settings: Impostazioni Sicurezza
@@ -1260,10 +1448,12 @@ it:
     ship_total: Totale Spedizione
     shipment: Spedizione
     shipment_adjustments: Variazioni spedizioni
-    shipment_details: "Da %{stock_location} via %{shipping_method}"
+    shipment_details: Da %{stock_location} via %{shipping_method}
     shipment_mailer:
       shipped_email:
-        dear_customer: "Gentile Cliente,\n"
+        dear_customer: 'Gentile Cliente,
+
+'
         instructions: Il tuo ordine è stato spedito
         shipment_summary: Riassunto Spedizione
         subject: Notifica di spedizione
@@ -1295,7 +1485,7 @@ it:
     shipping_methods: Metodi di Spedizione
     shipping_price_sack: Costo imballaggio
     shipping_total: Totale Spedizione
-    shop_by_taxonomy: "Acquista per %{taxonomy}"
+    shop_by_taxonomy: Acquista per %{taxonomy}
     shopping_cart: Carrello
     show: Visualizza
     show_active: Mostra Attivi
@@ -1359,7 +1549,7 @@ it:
     stock_management: Gestione Scorte
     stock_management_requires_a_stock_location: Per favore crea un Magazzino per poter gestire le scorte.
     stock_movements: Movimenti di Magazzino
-    stock_movements_for_stock_location: "Movimenti di Magazzino per %{stock_location_name}"
+    stock_movements_for_stock_location: Movimenti di Magazzino per %{stock_location_name}
     stock_successfully_transferred: Le scorte sono state trasferito con successo.
     stock_transfer: Trasferimento di Magazzino
     stock_transfers: Trasferimenti di Magazzino
@@ -1380,7 +1570,7 @@ it:
     subtract: Sottrai
     success: Successo
     successfully_created: "%{resource} è stata creata con successo!"
-    successfully_refunded: '%{resource} è stato rimborsato con successo!'
+    successfully_refunded: "%{resource} è stato rimborsato con successo!"
     successfully_removed: "%{resource} è stato rimosso con successo!"
     successfully_signed_up_for_analytics: Registrazione a Spree Analytics avvenuta con successo
     successfully_updated: "%{resource} è stata aggiornata con successo!"
@@ -1390,7 +1580,7 @@ it:
     tax_category: Categoria di Tassazione
     tax_code: Codice Tassa
     tax_included: Tassa (incl.)
-    tax_rate_amount_explanation: "Le aliquote sono specificate con valore decimale per facilitare le operazioni, (es. se l'aliquota è al 5% inserisci 0.05)"
+    tax_rate_amount_explanation: Le aliquote sono specificate con valore decimale per facilitare le operazioni, (es. se l'aliquota è al 5% inserisci 0.05)
     tax_rates: Aliquote
     taxon: Taxon
     taxon_edit: Modifica Taxon
@@ -1403,14 +1593,14 @@ it:
     taxonomies: Tassonomie
     taxonomy: Tassonomia
     taxonomy_edit: Modifica tassonomia
-    taxonomy_tree_error: "La modifica richiesta non è stata accettata e l'albero è stato riportato allo stato precedente, per favore riprova."
+    taxonomy_tree_error: La modifica richiesta non è stata accettata e l'albero è stato riportato allo stato precedente, per favore riprova.
     taxonomy_tree_instruction: "* Click destro su un nodo nell'albero per accedere al menu e aggiungere, rimuovere o ordinare."
     taxons: Taxon
     test: Test
     test_mailer:
       test_email:
         greeting: Congratulazioni!
-        message: "Se hai ricevuto questa email, allora le tue impostazioni email sono corrette."
+        message: Se hai ricevuto questa email, allora le tue impostazioni email sono corrette.
         subject: E-Mail di Test
     test_mode: Modalità Test
     thank_you_for_your_order: Grazie per il tuo ordine. Per favore stampa una copia di questa conferma come riferimento.
@@ -1422,7 +1612,7 @@ it:
     tiered_percent: Tariffa Fissa a Percentuale
     tiers: Livelli
     time: Ora
-    to_add_variants_you_must_first_define: "Per aggiungere varianti, devi prima definire"
+    to_add_variants_you_must_first_define: Per aggiungere varianti, devi prima definire
     total: Totale
     total_per_item: Totale per articolo
     total_pre_tax_refund: Totale Rimborso al lordo delle tasse
@@ -1463,10 +1653,10 @@ it:
       cannot_be_less_than_shipped_units: non può essere inferiore al numero di unità spedite.
       cannot_destroy_line_item_as_inventory_units_have_shipped: Impossibile eliminare le righe d'ordine poiché alcune unità di inventario sono state spedite.
       exceeds_available_stock: supera la disponibilità di magazzino. Per favore assicurati che la quantità degli articoli sia valida.
-      is_too_large: "è troppo grande -- il magazzino non può coprire la quantità richiesta!"
+      is_too_large: è troppo grande -- il magazzino non può coprire la quantità richiesta!
       must_be_int: deve essere un intero
       must_be_non_negative: deve essere un valore non negativo
-      unpaid_amount_not_zero: "L'importo non è stato completamente rimborsato. Rimangono: %{amount}"
+      unpaid_amount_not_zero: 'L''importo non è stato completamente rimborsato. Rimangono: %{amount}'
     value: Valore
     variant: Variante
     variant_placeholder: Scegli una variante
@@ -1482,8 +1672,32 @@ it:
     year: Anno
     you_have_no_orders_yet: Non hai alcun ordine
     your_cart_is_empty: Il tuo carrello è vuoto
-    your_order_is_empty_add_product: "Il tuo ordine è vuoto, per favore cerca e aggiungi un prodotto"
+    your_order_is_empty_add_product: Il tuo ordine è vuoto, per favore cerca e aggiungi un prodotto
     zip: Cap
     zipcode: Codice Cap
     zone: Zona
     zones: Zone
+    canceled: annullato
+    cannot_create_payment_link: Per favore definisci prima dei metodi di pagamento.
+    inventory_states:
+      canceled: annullato
+      returned: restituito
+      shipped: spedito
+    no_resource_found_link: Aggiungine Uno
+    number: Numero
+    store_credit:
+      display_action:
+        adjustment: Variazione
+        credit: Credito
+        void: Credito
+        admin:
+          authorize: Autorizzato
+    store_credit_category:
+      default: Default
+  activemodel:
+    attributes:
+      spree/order_cancellations:
+        quantity: Quantità
+        state: Stato
+        shipment: Spedizione
+        cancel: Annulla

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -24,7 +24,7 @@ it:
         iso_name: Nome ISO
         name: Nome
         numcode: Codice ISO
-        states_required: Stati Necessari
+        states_required: Province o Stati Necessari
       spree/credit_card:
         base: ''
         cc_type: Tipologia
@@ -66,7 +66,7 @@ it:
         approver_id: Approvatore
         canceled_at: Annullato il
         canceler_id: Annullatore
-        included_tax_total: Tassa (incl.)
+        included_tax_total: Tasse (incl.)
         shipment_total: Totale Spedizione
       spree/order/bill_address:
         address1: Indirizzo di fatturazione
@@ -112,7 +112,7 @@ it:
         meta_title: Meta Title
         price: Prezzo principale
         promotionable: Promuovibile
-        slug: Slug
+        slug: Permalink
         weight: Peso
         width: Larghezza
       spree/promotion:
@@ -201,7 +201,7 @@ it:
         label: Descrizione
         name: Nome
         state: Stato
-        adjustment_reason_id: Ragione
+        adjustment_reason_id: Motivazione
       spree/adjustment_reason:
         active: Attivo
         code: Codice
@@ -230,7 +230,7 @@ it:
       spree/refund:
         amount: Quantità
         description: Descrizione
-        refund_reason_id: Ragione
+        refund_reason_id: Motivazione
       spree/refund_reason:
         active: Attivo
         name: Nome
@@ -253,7 +253,7 @@ it:
         override_reimbursement_type_id: Override Tipologia Rimborso
         preferred_reimbursement_type_id: Tipologia di rimborso preferita
         reception_status:
-        return_reason: Ragione
+        return_reason: Motivazione
         total: Totale
       spree/return_reason:
         name: Nome
@@ -403,8 +403,8 @@ it:
         one: Prototipo
         other: Prototipi
       spree/refund_reason:
-        one: Ragione Rimborso
-        other: Ragioni Rimborso
+        one: Motivazione Rimborso
+        other: Motivazioni Rimborso
       spree/reimbursement:
         one: Rimborso
         other: Rimborsi
@@ -1180,7 +1180,7 @@ it:
         subtotal: 'Subtotale:'
         total: 'Totale Ordine:'
       confirm_email:
-        dear_customer: 'Caro Cliente,
+        dear_customer: 'Gentile Cliente,
 
 '
         instructions: Per favore rivedi queste informazioni e conservale come riferimento.
@@ -1350,7 +1350,7 @@ it:
     quantity_shipped: Quantità Spedita
     quick_search: Ricerca Veloce
     rate: Percentuale
-    reason: Ragione
+    reason: Motivazione
     receive: ricevi
     receive_stock: Ricevi Scorte
     received: Ricevuto


### PR DESCRIPTION
Recent changes made to admin translations in solidus moved many of the keys. This was done to better use the ActiveModel translation conventions.

I wrote a [script](https://github.com/StemboltHQ/solidus_i18n_convert) that scans through the locale files in solidus_i18n looking for missing keys when compared to `en.yml` in core. Since these translations are just moved, the script attempts to make the same moves in this locale as were made for english.

Reviews would be appreciated to find any blatant mistranslations.
