### PR TITLE
Fix wrong rails-i18n version in Gemfile for Rails5

### DIFF
--- a/solidus_i18n.gemspec
+++ b/solidus_i18n.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.has_rdoc = false
 
   s.add_runtime_dependency 'i18n_data', '~> 0.7.0'
-  s.add_runtime_dependency 'rails-i18n', '~> 4.0.1'
+  s.add_runtime_dependency 'rails-i18n', '~> 5.0.0'
   s.add_runtime_dependency 'kaminari-i18n', '~> 0.3.2'
   s.add_runtime_dependency 'routing-filter', '~> 0.6.0'
   s.add_runtime_dependency 'solidus_core', ['>= 1.1', '< 3']


### PR DESCRIPTION
I get this error when I execute bundle in my app:
```
solidus_i18n was resolved to 1.1.0, which depends on                                                                                   
      rails-i18n (~> 4.0.1) was resolved to 4.0.3, which depends on                                                                        
        railties (~> 4.0)
```