### PR TITLE
Explicitly use full constant name in locale helper

### DIFF
--- a/app/helpers/solidus_i18n/locale_helper.rb
+++ b/app/helpers/solidus_i18n/locale_helper.rb
@@ -15,7 +15,7 @@ module SolidusI18n
     # Need to manually add en to the array because the en.yml was moved from
     # this project. solidusio/solidus now has those keys.
     def all_locales_options
-      Locale.all.map { |locale| locale_presentation(locale) }.push(['English (EN)', :en])
+      SolidusI18n::Locale.all.map { |locale| locale_presentation(locale) }.push(['English (EN)', :en])
     end
 
     private

--- a/lib/solidus_i18n.rb
+++ b/lib/solidus_i18n.rb
@@ -1,6 +1,7 @@
 require 'rails-i18n'
 require 'solidus_core'
 require 'solidus_i18n/engine'
+require 'solidus_i18n/locale'
 require 'solidus_i18n/version'
 require 'solidus_i18n/utils'
 require 'coffee_script'


### PR DESCRIPTION
Sometimes Rails Module lockup causes errors like in https://github.com/solidusio-contrib/solidus_i18n/issues/73

Closes #73