### PR TITLE
Translate login/sign up/password recover pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source "https://rubygems.org"
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus", github: "solidusio/solidus", branch: branch
 
+# Provides basic authentication functionality for testing parts of your engine
+gem 'solidus_auth_devise', '~> 1.0'
+
 if branch == 'master' || branch >= "v2.0"
   gem "rails-controller-testing", group: :test
 end

--- a/app/controllers/spree/devise_controllers_decorator.rb
+++ b/app/controllers/spree/devise_controllers_decorator.rb
@@ -1,0 +1,8 @@
+begin
+  Spree::UserPasswordsController.include SolidusI18n::ControllerLocaleHelper
+  Spree::UserRegistrationsController.include SolidusI18n::ControllerLocaleHelper
+  Spree::UserSessionsController.include SolidusI18n::ControllerLocaleHelper
+  Spree::Admin::UserSessionsController.include SolidusI18n::ControllerLocaleHelper
+rescue NameError
+  # App is not using solidus_auth_devise
+end

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -470,7 +470,7 @@ it:
         add: Nuovo credito
         back_to_user_list: Lista utenti
         select_reason: Motivo
-    admin_login: Login
+    admin_login: Login amministratore
     administration: Amministrazione
     advertise: Promuovi
     agree_to_privacy_policy: Accetta Politica di Privacy
@@ -574,6 +574,7 @@ it:
       other: "Subtotale (%{count} articoli)"
     categories: Categorie
     category: Categoria
+    change_my_password: Cambia la mia password
     charged: Addebitato
     check_for_spree_alerts: Visualizza le segnalazioni di Spree
     checkout: Checkout

--- a/spec/features/admin/translations_spec.rb
+++ b/spec/features/admin/translations_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.feature 'Translations', :js do
+RSpec.feature 'Admin translations', :js do
   stub_authorization!
 
   given!(:store) { create(:store) }
@@ -29,6 +29,19 @@ RSpec.feature 'Translations', :js do
       targetted_select2_search(french, from: '#s2id_available_locales_')
       click_on 'Update'
       expect(SolidusI18n::Config.available_locales).to include(:fr)
+    end
+  end
+
+  context 'solidus_auth_devise pages translation' do
+    let(:locale) { :it }
+
+    background do
+      SolidusI18n::Config.available_locales = [:en, :it]
+    end
+
+    scenario 'the login page is translated' do
+      visit spree.admin_login_path(locale: locale)
+      expect(page).to have_content(/#{Spree.t(:admin_login, locale: locale)}/i)
     end
   end
 end

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -1,12 +1,12 @@
 # encoding: utf-8
 require 'spec_helper'
 
-RSpec.feature 'Translations', :js do
+RSpec.feature 'Frontend translations', :js do
   given(:language) { Spree.t(:this_file_language, scope: 'i18n', locale: 'pt-BR') }
 
   background do
     reset_spree_preferences
-    SolidusI18n::Config.available_locales = [:en, :'pt-BR']
+    SolidusI18n::Config.available_locales = [:en, :'pt-BR', :it]
   end
 
   context 'page' do
@@ -23,6 +23,30 @@ RSpec.feature 'Translations', :js do
       scenario 'JS cart link is translated' do
         expect(page).to have_content(/#{Spree.t(:cart, locale: 'pt-BR')}/i)
       end
+    end
+  end
+
+  context 'solidus_auth_devise pages translation' do
+    let(:locale) { :it }
+
+    scenario 'the login page is translated' do
+      visit spree.login_path(locale: locale)
+      expect(page).to have_content(/#{Spree.t(:login_as_existing, locale: locale)}/i)
+    end
+
+    scenario 'the signup page is translated' do
+      visit spree.signup_path(locale: locale)
+      expect(page).to have_content(/#{Spree.t(:new_customer, locale: locale)}/i)
+    end
+
+    scenario 'the forgot password page is translated' do
+      visit spree.recover_password_path(locale: locale)
+      expect(page).to have_content(/#{Spree.t(:forgot_password, locale: locale)}/i)
+    end
+
+    scenario 'the change password page is translated' do
+      visit spree.edit_password_path(locale: locale, reset_password_token: "123")
+      expect(page).to have_content(/#{Spree.t(:change_my_password, locale: locale)}/i)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.syntax = :expect
   end
+
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end
 
 Dir[File.join(File.dirname(__FILE__), '/support/**/*.rb')].each { |file| require file }


### PR DESCRIPTION
The `SolidusI18n::ControllerLocaleHelper` module is required to translate pages.
This is included on `Spree::BaseController` but not on the `solidus_auth_devise` controllers.

This PR adds the module to the missing controllers.