### PR TITLE
Remove bundler downgrade on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,3 @@ env:
     - SOLIDUS_BRANCH=v2.1 DB=mysql
     - SOLIDUS_BRANCH=v2.2 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql
-before_install:
-  - rvm use @global
-  - gem uninstall bundler -x
-  - gem install bundler --version=1.13.7
-  - bundler --version


### PR DESCRIPTION
The old version of bundler has now started failing with

    NoMethodError: undefined method `to_specs' for nil:NilClass