### PR TITLE
Build on precise because of Travis MySQL problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Need to stay on precise until Travis fixes their MySQL problems
+# See: https://github.com/travis-ci/travis-ci/issues/8331
+dist: precise
 sudo: false
 cache: bundler
 language: ruby


### PR DESCRIPTION
Travis recently switched to trusty build environment but broke
MySQL builds by removing database create privileges.

See: https://github.com/travis-ci/travis-ci/issues/8331