### PR TITLE
Fix reception states translations (spanish and catalan)

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1027,7 +1027,18 @@ ca:
     receive: rebre
     receive_stock:
     received: Rebut
-    reception_status:
+    reception_states:
+      awaiting: En espera
+      cancelled: Cancel·lat
+      expired: Expirat
+      given_to_customer: Entregat al client
+      in_transit: En trànsit
+      lost_in_transit: Perdut en trànsit
+      received: Rebut
+      shipped_wrong_item: Article incorrecte
+      short_shipped: No inclòs en l'enviament
+      unexchanged: Sense canvis
+    reception_status: Estat de recepció
     reference:
     refund: Retornar
     refund_amount_must_be_greater_than_zero:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1730,14 +1730,14 @@ es:
     receiving_match: Recibiendo match
     reception_states:
       awaiting: En espera
-      canceled: Cancelado
+      cancelled: Cancelado
       expired: Expirado
-      given_to_customer: Dado al cliente
+      given_to_customer: Entregado al cliente
       in_transit: En tránsito
       lost_in_transit: Perdido en tránsito
       received: Recibido
       shipped_wrong_item: Artículo incorrecto
-      short_shipped: Envío corto
+      short_shipped: No incluido en el envío
       unexchanged: Sin cambios
     reception_status: Estado Recepción
     reference: Referencia


### PR DESCRIPTION
The translation key for Canceled state is with double l: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_item.rb#L83