### PR TITLE
Improve Locale.all and all_locales_options

### DIFF
--- a/app/helpers/solidus_i18n/locale_helper.rb
+++ b/app/helpers/solidus_i18n/locale_helper.rb
@@ -12,10 +12,8 @@ module SolidusI18n
       Config.available_locales.map { |locale| locale_presentation(locale) }
     end
 
-    # Need to manually add en to the array because the en.yml was moved from
-    # this project. solidusio/solidus now has those keys.
     def all_locales_options
-      SolidusI18n::Locale.all.map { |locale| locale_presentation(locale) }.push(['English (EN)', :en])
+      SolidusI18n::Locale.all.map { |locale| locale_presentation(locale) }
     end
 
     private

--- a/config/locales/en-IN.yml
+++ b/config/locales/en-IN.yml
@@ -631,7 +631,7 @@ en-IN:
       available_locales:
       language:
       localization_settings:
-      this_file_language: English (UK)
+      this_file_language: English (IN)
     icon: Icon
     identifier:
     image: Image

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -636,7 +636,7 @@ es-MX:
       available_locales: Traduciones Disponibles
       language: Idioma
       localization_settings: Ajustes de traducciones
-      this_file_language:
+      this_file_language: Castellano (MX)
     icon: Icono
     identifier:
     image: Imagen

--- a/lib/solidus_i18n/locale.rb
+++ b/lib/solidus_i18n/locale.rb
@@ -1,12 +1,8 @@
 module SolidusI18n
   class Locale
-    class << self
-      def all
-        Dir["#{dir}/*.yml"].map { |f| File.basename(f, '.yml').to_sym }
-      end
-
-      def dir
-        File.join(File.dirname(__FILE__), '/../../config/locales')
+    def self.all
+      I18n.available_locales.select do |locale|
+        I18n.t(:spree, locale: locale, fallback: false, default: nil)
       end
     end
   end

--- a/spec/helpers/locale_helper_spec.rb
+++ b/spec/helpers/locale_helper_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe SolidusI18n::LocaleHelper do
+  describe '#all_locales_options' do
+    subject { all_locales_options }
+
+    it 'includes en' do
+      is_expected.to include(["English (US)", :en])
+    end
+
+    it 'includes ja' do
+      is_expected.to include(["日本語 (ja-JP)", :ja])
+    end
+
+    describe 'locales' do
+      subject { all_locales_options.map(&:last) }
+
+      it 'includes each locale only once' do
+        is_expected.to match_array(subject.uniq)
+      end
+
+      it 'should match Locale.all' do
+        is_expected.to match_array SolidusI18n::Locale.all
+      end
+    end
+  end
+end

--- a/spec/helpers/locale_helper_spec.rb
+++ b/spec/helpers/locale_helper_spec.rb
@@ -23,5 +23,13 @@ RSpec.describe SolidusI18n::LocaleHelper do
         is_expected.to match_array SolidusI18n::Locale.all
       end
     end
+
+    describe 'locale presentation' do
+      subject { all_locales_options.map(&:first) }
+
+      it 'should all be unique' do
+        is_expected.to match_array(subject.uniq)
+      end
+    end
   end
 end

--- a/spec/lib/solidus_i18n/locale_spec.rb
+++ b/spec/lib/solidus_i18n/locale_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe SolidusI18n::Locale do
+  describe '.all' do
+    subject { SolidusI18n::Locale.all }
+
+    it "Contains all available Solidus locales" do
+      # Add to this list when adding/removing locales
+      expect(subject).to match_array %i[
+        zh-CN
+        cs
+        zh-TW
+        it
+        nl
+        da
+        tr
+        id
+        ro
+        pt-BR
+        ja
+        es
+        fr
+        de
+        ru
+        uk
+        ko
+        pt
+        et
+        sk
+        pl
+        nb
+        fa
+        fi
+        en-NZ
+        en-IN
+        en-AU
+        bg
+        en-GB
+        de-CH
+        es-MX
+        es-CL
+        th
+        ca
+        vi
+        sv
+        es-EC
+        lv
+        sl-SI
+      ]
+    end
+  end
+end

--- a/spec/lib/solidus_i18n/locale_spec.rb
+++ b/spec/lib/solidus_i18n/locale_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SolidusI18n::Locale do
     it "Contains all available Solidus locales" do
       # Add to this list when adding/removing locales
       expect(subject).to match_array %i[
+        en
         zh-CN
         cs
         zh-TW


### PR DESCRIPTION
We used to scan the `config/locales` directory of this project to determine available locales. This missed `en`, so that was added manually in a helper.

This PR changes that to instead scan `I18n.available_locales` for locales which have anything under `t(:spree)` and removes the hardcoded `English (EN)` (which is now also correctly "English (US)").

It also fixes `en-IN` and `es-MX` misidentifying as duplicated `"English (UK)"` and `"Castellano (ES)"` respectively.