### PR TITLE
Update fr.yml in taxon_rule

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1466,7 +1466,8 @@ fr:
       choose_taxons: Choisissez taxons
       label: Commande doit contenir %{select} de ces taxons
       match_all: tout
-      match_any: aucun
+      match_any: un ou plusieurs
+      matcn_none: aucun
     taxonomies: Arborescences
     taxonomy: Taxonomy
     taxonomy_edit: Modifier l'aborescence


### PR DESCRIPTION
The appropriate translation for match any in french would be better suited with "un ou plusieurs" which translates to "one or more".
I also moved the string "aucun" to match_none.