### PR TITLE
Call super from set_user_language

### DIFF
--- a/lib/solidus_i18n/controller_locale_helper.rb
+++ b/lib/solidus_i18n/controller_locale_helper.rb
@@ -6,8 +6,6 @@ module SolidusI18n
     extend ActiveSupport::Concern
 
     included do
-      prepend_before_action :set_user_language
-
       private
 
       # Overrides the Spree::Core::ControllerHelpers::Common logic so that only
@@ -15,13 +13,11 @@ module SolidusI18n
       # actually be set
       def set_user_language
         # params[:locale] can be added by routing-filter gem
-        I18n.locale = \
+        I18n.locale =
           if params[:locale] && current_store.preferred_available_locales.include?(params[:locale].to_sym)
             params[:locale]
-          elsif respond_to?(:config_locale, true) && !config_locale.blank?
-            config_locale
           else
-            Rails.application.config.i18n.default_locale || I18n.default_locale
+            super
           end
       end
     end


### PR DESCRIPTION
This allows reusing the existing implementation in Solidus's `controller_helpers/common`, which is in some ways better than the implementation here.

This also removes the `prepend_before_action`, since it is already added as a `before_action` in Solidus itself.