### PR TITLE
Do not configure the fallback locale

### DIFF
--- a/lib/solidus_i18n/engine.rb
+++ b/lib/solidus_i18n/engine.rb
@@ -17,7 +17,6 @@ module SolidusI18n
     end
 
     initializer 'solidus.i18n.environment', before: :load_config_initializers do |app|
-      app.config.i18n.fallbacks = true
       I18n.locale = app.config.i18n.default_locale if app.config.i18n.default_locale
       SolidusI18n::Config = SolidusI18n::Configuration.new
     end


### PR DESCRIPTION
This is a setting the host app should be making.

This is what it does: It adds the `default_locale` as
a fallback locale to all `available_locales`. This means
that for a store with e.g. a German default locale and en English
locale, missing English translations would be replaced by
their German equivalents rather than show up as missing
translations.

This fallback locale feature is very nice, but not very well
documented, and should IMO not be triggered from any gem's
initializer.